### PR TITLE
Change to when records are considered answered

### DIFF
--- a/modules/cache_builder/config/cache_builder.php
+++ b/modules/cache_builder/config/cache_builder.php
@@ -738,7 +738,7 @@ $config['occurrences']['update'] = "update cache_occurrences co
       sref_precision=round(coalesce(spv.int_value, spv.float_value)),
       query=case
         when oc1.id is null then null
-        when oc2.id is null then 'Q'
+        when oc2.id is null and o.updated_on<=oc1.created_on then 'Q'
         else 'A'
       end
     from occurrences o


### PR DESCRIPTION
Records are considered answered now if ANY change is made after the
query comment. It used to be only if there was a further comment.