### PR TITLE
Report services support for metadata

### DIFF
--- a/application/libraries/ReportEngine.php
+++ b/application/libraries/ReportEngine.php
@@ -222,6 +222,20 @@ class ReportEngine {
     );
   }
 
+  public function requestMetadata($report) {
+    $this->fetchLocalReport($report);
+    $this->reportReader = new XMLReportReader($this->report, $this->websiteIds);
+    $this->providedParams = array();
+    $this->reportReader->loadStandardParams($this->providedParams, $this->sharingMode);
+    $this->prepareColumns();
+    $r = array(
+      'columns'=>$this->columns,
+      'parameters'=>$this->reportReader->getParams()
+    );
+
+    return $r;
+  }
+
   /**
   * Checks parameters and returns request if they're not all there, else compiles the report.
   *

--- a/application/views/report/index.php
+++ b/application/views/report/index.php
@@ -27,6 +27,9 @@ require_once(DOCROOT.'client_helpers/report_helper.php');
 $readAuth = report_helper::get_read_auth(0-$_SESSION['auth_user']->id, kohana::config('indicia.private_key'));
 echo report_helper::report_picker(array('readAuth'=>$readAuth));
 report_helper::link_default_stylesheet();
+report_helper::$dumped_resources[] = 'jquery';
+report_helper::$dumped_resources[] = 'jquery_ui';
+report_helper::$dumped_resources[] = 'fancybox';
 echo report_helper::dump_javascript();
 ?>
 <input type="submit" value="Load report" />

--- a/modules/indicia_svc_data/controllers/services/report.php
+++ b/modules/indicia_svc_data/controllers/services/report.php
@@ -106,6 +106,20 @@ class Report_Controller extends Data_Service_Base_Controller {
     }
   }
 
+  public function requestMetadata() {
+    $this->setup();
+    $data = $this->reportEngine->requestMetadata($_GET['report']);
+    $r = json_encode($data);
+    if (array_key_exists('callback', $_REQUEST))
+    {
+      $r = $_REQUEST['callback']."(".$r.")";
+      $this->content_type = 'Content-Type: application/javascript';
+    } else {
+      $this->content_type = 'Content-Type: application/json';
+    }
+    echo $r;
+  }
+
   /**
    * Method called via report services to return a JSON encoded nested array of the available reporting directory structure.
    */


### PR DESCRIPTION
Requesting report metadata now possible via requestMetadata service.