### PR TITLE
Fix possible incorrect record substatuses

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -26,8 +26,8 @@ defined('SYSPATH') or die('No direct script access.');
 /**
  * @var string The application files version number.
  */
-$config['version'] = '0.9.1.4';
-$config['release_date']  = '2015-10-02';
+$config['version'] = '0.9.1.5';
+$config['release_date']  = '2015-10-07';
 $config['repository'] = 'https://github.com/Indicia-Team/warehouse/releases';
 
 ?>

--- a/application/models/occurrence.php
+++ b/application/models/occurrence.php
@@ -81,7 +81,8 @@ class Occurrence_Model extends ORM
   public function validate(Validation $array, $save = false) {
     if ($save) 
       $this->logDeterminations($array);
-    if ($this->id && preg_match('/[RDV]/', $this->record_status) && empty($this->submission['fields']['record_status']) && 
+    if ($this->id && preg_match('/[RDV]/', $this->record_status) && 
+        (empty($this->submission['fields']['record_status']) || $this->submission['fields']['record_status']['value']==='C') && 
         empty($this->submission['fields']['release_status']) && $this->wantToUpdateMetadata) {
       // If we update a processed occurrence but don't set the verification or release state, revert it to completed/awaiting verification.
       $array->verified_by_id=null;

--- a/application/models/sample.php
+++ b/application/models/sample.php
@@ -78,7 +78,8 @@ class Sample_Model extends ORM_Tree
     // uses PHP trim() to remove whitespace from beginning and end of all fields before validation
     $array->pre_filter('trim');
 
-    if ($this->id && preg_match('/[RDV]/', $this->record_status) && empty($this->submission['fields']['record_status'])
+    if ($this->id && preg_match('/[RDV]/', $this->record_status) && 
+        (empty($this->submission['fields']['record_status']) || $this->submission['fields']['record_status']['value']==='C') && 
         && $this->wantToUpdateMetadata) {
       // If we update a processed occurrence but don't set the verification state, revert it to completed/awaiting verification.
       $array->verified_by_id=null;


### PR DESCRIPTION
If a record was verified as V1 or V2, then edited on a single record
form that had a hidden input setting occurrence:record_status to 'C'
then this forcing of the record status prevented the code firing on
the occurrence (or sample) model to correctly clean out the prior
verification status. This could result in incorrect status + substatus
combinations.