### PR TITLE
For #21, removes aggregation on VC column for performance

### DIFF
--- a/reports/library/occurrences/filterable_nbn_exchange.xml
+++ b/reports/library/occurrences/filterable_nbn_exchange.xml
@@ -7,9 +7,9 @@ select #columns#
 from cache_occurrences o
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
-  join locations l on l.id=ils.location_id
-  join cache_termlists_terms ctt on ctt.id=l.location_type_id and ctt.term='Vice County'
-) on ils.sample_id=o.sample_id
+  join locations vc on vc.id=ils.location_id
+  join cache_termlists_terms ctt on ctt.id=vc.location_type_id and ctt.term='Vice County'
+) on ils.sample_id=o.sample_id and ils.contains=true
 left join groups g1 on g1.id=o.group_id and g1.deleted=false
 left join group_relations grel on grel.to_group_id=g1.id and grel.deleted=false
 left join groups g2 on g2.id=grel.from_group_id and g2.deleted=false
@@ -57,7 +57,7 @@ and st_y(st_transform(st_centroid(public_geom), 4326)) between -48 and 62
     else case length(replace(s.entered_sref, ' ', '')) when 5 then 2000 else pow(10, (12-length(replace(s.entered_sref, ' ', '')))/2) end
   end" 
         datatype="text" />
-    <column name="vicecounty" display="ViceCounty" sql="array_to_string(array_agg(l.name), ', ')" datatype="text" aggregate="true" />        
+    <column name="vicecounty" display="ViceCounty" sql="vc.name" datatype="text" />        
     <column name='recorder' display='Recorder' sql='o.recorders' datatype="text" />
     <column name='verifier' display='Verifier' sql='o.verifier' datatype="text" />
     <column name='source_group' display='SourceGroup' sql="coalesce(g2.title || '::', '') || g1.title" datatype="text" />

--- a/reports/library/occurrences/filterable_occurrences_download.xml
+++ b/reports/library/occurrences/filterable_occurrences_download.xml
@@ -9,9 +9,9 @@
   JOIN cache_taxa_taxon_lists cttl on cttl.id=o.taxa_taxon_list_id
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
-    JOIN locations l on l.id=ils.location_id
-    JOIN cache_termlists_terms ctt on ctt.id=l.location_type_id AND ctt.term='Vice County'
-  ) on ils.sample_id=o.sample_id
+    JOIN locations vc on vc.id=ils.location_id
+    JOIN cache_termlists_terms ctt on ctt.id=vc.location_type_id AND ctt.term='Vice County'
+  ) on ils.sample_id=o.sample_id and ils.contains=true
   LEFT JOIN (occurrence_attribute_values det_full_val
     JOIN occurrence_attributes det_full on det_full.id=det_full_val.occurrence_attribute_id and det_full.deleted=false and det_full.system_function='det_full_name'
   ) ON det_full_val.occurrence_id=o.id AND det_full_val.deleted=false
@@ -72,7 +72,7 @@
   end" 
         datatype="text" />
     <column name='output_sref' display='Output grid ref' sql="o.output_sref" datatype='text' />
-    <column name="vicecounty" display="Vice county" sql="array_to_string(array_agg(l.name), ', ')" datatype="text" aggregate="true" />
+    <column name="vicecounty" display="Vice county" sql="vc.name" datatype="text" />
     <column name='date_start' sql='o.date_start' visible='false' />
     <column name='date_end' sql='o.date_end' visible='false' />
     <column name='date_type' sql='o.date_type' visible='false' />

--- a/reports/library/occurrences/filterable_occurrences_download_gis.xml
+++ b/reports/library/occurrences/filterable_occurrences_download_gis.xml
@@ -8,9 +8,9 @@
   JOIN occurrences occ on occ.id=o.id and occ.deleted=false -- to get comments
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
-    JOIN locations l on l.id=ils.location_id
-    JOIN cache_termlists_terms ctt on ctt.id=l.location_type_id AND ctt.term='Vice County'
-  ) on ils.sample_id=o.sample_id
+    JOIN locations vc on vc.id=ils.location_id
+    JOIN cache_termlists_terms ctt on ctt.id=vc.location_type_id AND ctt.term='Vice County'
+  ) on ils.sample_id=o.sample_id and ils.contains=true
   LEFT JOIN (occurrence_attribute_values det_full_val
     JOIN occurrence_attributes det_full on det_full.id=det_full_val.occurrence_attribute_id and det_full.deleted=false and det_full.system_function='det_full_name'
   ) ON det_full_val.occurrence_id=o.id AND det_full_val.deleted=false
@@ -69,7 +69,7 @@
   end" 
         datatype="text" />
     <column name='output_sref' display='Output grid ref' sql="o.output_sref" datatype='text' />
-    <column name="vicecounty" display="Vice county" sql="array_to_string(array_agg(l.name), ', ')" datatype="text" aggregate="true" />
+    <column name="vicecounty" display="Vice county" sql="vc.name" datatype="text" />
     <column name='date_start' sql='o.date_start' visible='false' />
     <column name='date_end' sql='o.date_end' visible='false' />
     <column name='date_type' sql='o.date_type' visible='false' />

--- a/reports/library/occurrences/filterable_occurrences_download_parent_samples.xml
+++ b/reports/library/occurrences/filterable_occurrences_download_parent_samples.xml
@@ -9,9 +9,9 @@
   JOIN cache_taxa_taxon_lists cttl on cttl.id=o.taxa_taxon_list_id
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
-    JOIN locations l on l.id=ils.location_id
-    JOIN cache_termlists_terms ctt on ctt.id=l.location_type_id AND ctt.term='Vice County'
-  ) on ils.sample_id=o.sample_id
+    JOIN locations vc on vc.id=ils.location_id
+    JOIN cache_termlists_terms ctt on ctt.id=vc.location_type_id AND ctt.term='Vice County'
+  ) on ils.sample_id=o.sample_id and ils.contains=true
   LEFT JOIN (occurrence_attribute_values det_full_val
     JOIN occurrence_attributes det_full on det_full.id=det_full_val.occurrence_attribute_id and det_full.deleted=false and det_full.system_function='det_full_name'
   ) ON det_full_val.occurrence_id=o.id AND det_full_val.deleted=false
@@ -72,7 +72,7 @@
   end"
         datatype="text" />
     <column name='output_sref' display='Output grid ref' sql="o.output_sref" datatype='text' />
-    <column name="vicecounty" display="Vice county" sql="array_to_string(array_agg(l.name), ', ')" datatype="text" aggregate="true" />
+    <column name="vicecounty" display="Vice county" sql="vc.name" datatype="text" />
     <column name='date_start' sql='o.date_start' visible='false' />
     <column name='date_end' sql='o.date_end' visible='false' />
     <column name='date_type' sql='o.date_type' visible='false' />

--- a/reports/library/occurrences/filterable_occurrences_download_sensitive.xml
+++ b/reports/library/occurrences/filterable_occurrences_download_sensitive.xml
@@ -9,9 +9,9 @@
   JOIN cache_taxa_taxon_lists cttl on cttl.id=o.taxa_taxon_list_id
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
-    JOIN locations l on l.id=ils.location_id
-    JOIN cache_termlists_terms ctt on ctt.id=l.location_type_id AND ctt.term='Vice County'
-  ) on ils.sample_id=o.sample_id
+    JOIN locations vc on vc.id=ils.location_id
+    JOIN cache_termlists_terms ctt on ctt.id=vc.location_type_id AND ctt.term='Vice County'
+  ) on ils.sample_id=o.sample_id and ils.contains=true
   LEFT JOIN (occurrence_attribute_values det_full_val
     JOIN occurrence_attributes det_full on det_full.id=det_full_val.occurrence_attribute_id and det_full.deleted=false and det_full.system_function='det_full_name'
   ) ON det_full_val.occurrence_id=o.id AND det_full_val.deleted=false
@@ -72,7 +72,7 @@
   end" 
         datatype="text" />
     <column name='output_sref' display='Output grid ref' sql="o.output_sref" datatype='text' />
-    <column name="vicecounty" display="Vice county" sql="array_to_string(array_agg(l.name), ', ')" datatype="text" aggregate="true" />
+    <column name="vicecounty" display="Vice county" sql="vc.name" datatype="text" />
     <column name='date_start' sql='o.date_start' visible='false' />
     <column name='date_end' sql='o.date_end' visible='false' />
     <column name='date_type' sql='o.date_type' visible='false' />


### PR DESCRIPTION
Only outputs the VC if the record is fully contained within.
Therefore no need to aggregate if records overlap boundaries.