### PR TITLE
Hotfix nbn downloads

### DIFF
--- a/reports/library/occurrences/filterable_nbn_exchange.xml
+++ b/reports/library/occurrences/filterable_nbn_exchange.xml
@@ -7,7 +7,7 @@ select #columns#
 from cache_occurrences o
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
-  join locations vc on vc.id=ils.location_id
+  join locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
   join cache_termlists_terms ctt on ctt.id=vc.location_type_id and ctt.term='Vice County'
 ) on ils.sample_id=o.sample_id and ils.contains=true
 left join groups g1 on g1.id=o.group_id and g1.deleted=false

--- a/reports/library/occurrences/filterable_nbn_exchange.xml
+++ b/reports/library/occurrences/filterable_nbn_exchange.xml
@@ -20,7 +20,7 @@ and o.date_type in ('D','DD','O','OO','Y','YY','-Y','U')
 and (s.entered_sref_system ilike 'osgb' or s.entered_sref_system ilike 'osie' or s.entered_sref_system = '4326' or s.entered_sref_system = '27700')
 and o.taxa_taxon_list_external_key is not null
 and st_x(st_transform(st_centroid(public_geom), 4326)) between -14 and 13
-and st_y(st_transform(st_centroid(public_geom), 4326)) between -48 and 62
+and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
 #idlist#
   </query>
   

--- a/reports/library/occurrences/filterable_occurrences_download.xml
+++ b/reports/library/occurrences/filterable_occurrences_download.xml
@@ -9,7 +9,7 @@
   JOIN cache_taxa_taxon_lists cttl on cttl.id=o.taxa_taxon_list_id
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
-    JOIN locations vc on vc.id=ils.location_id
+    JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
     JOIN cache_termlists_terms ctt on ctt.id=vc.location_type_id AND ctt.term='Vice County'
   ) on ils.sample_id=o.sample_id and ils.contains=true
   LEFT JOIN (occurrence_attribute_values det_full_val

--- a/reports/library/occurrences/filterable_occurrences_download_gis.xml
+++ b/reports/library/occurrences/filterable_occurrences_download_gis.xml
@@ -8,7 +8,7 @@
   JOIN occurrences occ on occ.id=o.id and occ.deleted=false -- to get comments
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
-    JOIN locations vc on vc.id=ils.location_id
+    JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
     JOIN cache_termlists_terms ctt on ctt.id=vc.location_type_id AND ctt.term='Vice County'
   ) on ils.sample_id=o.sample_id and ils.contains=true
   LEFT JOIN (occurrence_attribute_values det_full_val

--- a/reports/library/occurrences/filterable_occurrences_download_parent_samples.xml
+++ b/reports/library/occurrences/filterable_occurrences_download_parent_samples.xml
@@ -9,7 +9,7 @@
   JOIN cache_taxa_taxon_lists cttl on cttl.id=o.taxa_taxon_list_id
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
-    JOIN locations vc on vc.id=ils.location_id
+    JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
     JOIN cache_termlists_terms ctt on ctt.id=vc.location_type_id AND ctt.term='Vice County'
   ) on ils.sample_id=o.sample_id and ils.contains=true
   LEFT JOIN (occurrence_attribute_values det_full_val

--- a/reports/library/occurrences/filterable_occurrences_download_sensitive.xml
+++ b/reports/library/occurrences/filterable_occurrences_download_sensitive.xml
@@ -9,7 +9,7 @@
   JOIN cache_taxa_taxon_lists cttl on cttl.id=o.taxa_taxon_list_id
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
-    JOIN locations vc on vc.id=ils.location_id
+    JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
     JOIN cache_termlists_terms ctt on ctt.id=vc.location_type_id AND ctt.term='Vice County'
   ) on ils.sample_id=o.sample_id and ils.contains=true
   LEFT JOIN (occurrence_attribute_values det_full_val

--- a/reports/library/occurrences/nbn_exchange.xml
+++ b/reports/library/occurrences/nbn_exchange.xml
@@ -8,7 +8,7 @@ from cache_occurrences co
 join occurrences o on o.id=co.id -- ensure we have the latest status. Would not be needed if cache_occurrences reflects updated immediately
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
-  join locations l on l.id=ils.location_id
+  join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
   join cache_termlists_terms ctt on ctt.id=l.location_type_id and ctt.term='Vice County'
 ) on ils.sample_id=co.sample_id
 #agreements_join#

--- a/reports/library/occurrences/nbn_exchange.xml
+++ b/reports/library/occurrences/nbn_exchange.xml
@@ -22,7 +22,7 @@ and (trim('#date_to#')='' or '#date_to#'='Click here' or co.date_start &lt;= CAS
 and quality_check('#quality#', co.record_status, co.certainty)=true
 and co.taxa_taxon_list_external_key is not null
 and st_x(st_transform(st_centroid(public_geom), 4326)) between -14 and 13
-and st_y(st_transform(st_centroid(public_geom), 4326)) between -48 and 62
+and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
  
   </query>
   

--- a/reports/library/occurrences/nbn_exchange_by_input_date.xml
+++ b/reports/library/occurrences/nbn_exchange_by_input_date.xml
@@ -24,7 +24,7 @@ and (trim('#date_to#')='' or '#date_to#'='Click here'
 and quality_check('#quality#', co.record_status, co.certainty)=true
 and co.taxa_taxon_list_external_key is not null
 and st_x(st_transform(st_centroid(public_geom), 4326)) between -14 and 13
-and st_y(st_transform(st_centroid(public_geom), 4326)) between -48 and 62
+and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
  
   </query>
   

--- a/reports/library/occurrences/nbn_exchange_by_input_date.xml
+++ b/reports/library/occurrences/nbn_exchange_by_input_date.xml
@@ -8,7 +8,7 @@ from cache_occurrences co
 join occurrences o on o.id=co.id -- ensure we have the latest status. Would not be needed if cache_occurrences reflects updated immediately
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
-  join locations l on l.id=ils.location_id
+  join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
   join cache_termlists_terms ctt on ctt.id=l.location_type_id and ctt.term='Vice County'
 ) on ils.sample_id=co.sample_id
 #agreements_join#

--- a/reports/library/occurrences/nbn_exchange_by_input_date_using_spatial_index_builder.xml
+++ b/reports/library/occurrences/nbn_exchange_by_input_date_using_spatial_index_builder.xml
@@ -9,7 +9,7 @@ from cache_occurrences co
 join occurrences o on o.id=co.id -- ensure we have the latest status. Would not be needed if cache_occurrences reflects updated immediately
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
-  join locations l on l.id=ils.location_id
+  join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
   join cache_termlists_terms ctt on ctt.id=l.location_type_id and ctt.term='Vice County'
 ) on ils.sample_id=co.sample_id
 #agreements_join#

--- a/reports/library/occurrences/nbn_exchange_by_input_date_using_spatial_index_builder.xml
+++ b/reports/library/occurrences/nbn_exchange_by_input_date_using_spatial_index_builder.xml
@@ -25,7 +25,7 @@ and (trim('#date_to#')='' or '#date_to#'='Click here'
 and quality_check('#quality#', co.record_status, co.certainty)=true
 and co.taxa_taxon_list_external_key is not null
 and st_x(st_transform(st_centroid(public_geom), 4326)) between -14 and 13
-and st_y(st_transform(st_centroid(public_geom), 4326)) between -48 and 62
+and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
  
   </query>
   


### PR DESCRIPTION
* Faked “compound” VCs, used to allocate verifiers e.g. to Sussex or
Yorkshire, were causing duplication in download report outputs. Fixed.
* Correct latitude restrictions for NBN downloads