### PR TITLE
Ensured that all reports link smpattr parameters correctly

### DIFF
--- a/application/libraries/XMLReportReader.php
+++ b/application/libraries/XMLReportReader.php
@@ -134,7 +134,7 @@ class XMLReportReader_Core implements ReportReader
                   $this->surveys_id_field = 'su.id';
                 if (!$this->samples_id_field = $reader->getAttribute('samples_id_field'))
                   // default table alias for the samples table, so we can join to the id
-                  $this->samples_id_field = 'o.sample_id';
+                  $this->samples_id_field = 's.id';
                 if (!$this->samples2_id_field = $reader->getAttribute('samples2_id_field'))
                   // default table alias for the second samples table, so we can join to the id: used when geting attributes for both in a parent/child arrangement 
                   $this->samples2_id_field = 's2.id';

--- a/reports/library/occurrence_images/explore_list.xml
+++ b/reports/library/occurrence_images/explore_list.xml
@@ -2,7 +2,7 @@
     title="Explore photos"
     description="Report designed for the explore photos facility in iRecord."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT #columns#
   FROM cache_occurrences o
   JOIN websites w on w.id=o.website_id 

--- a/reports/library/occurrence_images/explore_list_2.xml
+++ b/reports/library/occurrence_images/explore_list_2.xml
@@ -2,7 +2,7 @@
     title="Explore photos 2"
     description="Report designed for the explore photos facility in iRecord, with additional filter parameters."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT #columns#
   FROM cache_occurrences o
   JOIN websites w on w.id=o.website_id 

--- a/reports/library/occurrence_images/explore_list_using_spatial_index_builder.xml
+++ b/reports/library/occurrence_images/explore_list_using_spatial_index_builder.xml
@@ -4,7 +4,7 @@
         Spatial Index Builder module to index the list of locations that users can set in their preferences
         as their locality, for significantly improved performance."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT #columns#
   FROM cache_occurrences o
   JOIN websites w on w.id=o.website_id 

--- a/reports/library/occurrences/cached_occurrence_list_for_location_boundary.xml
+++ b/reports/library/occurrences/cached_occurrence_list_for_location_boundary.xml
@@ -2,7 +2,7 @@
     title="Cached occurrence list for location boundary"
     description="A general purpose list of records filtered to the contents of a selected location's boundary. Uses the cache tables so fast, but there is a lag before data appears."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT #field_sql#
   FROM cache_occurrences o
   #joins#

--- a/reports/library/occurrences/occurrences_list.xml
+++ b/reports/library/occurrences/occurrences_list.xml
@@ -2,7 +2,7 @@
     title="Occurrence list"
     description="A general purpose list of records."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT #field_sql#
   FROM cache_occurrences o
   #joins#

--- a/reports/library/occurrences/occurrences_list_for_cms_user.xml
+++ b/reports/library/occurrences/occurrences_list_for_cms_user.xml
@@ -2,7 +2,7 @@
     title="Occurrence list for a CMS user"
     description="A general purpose list of records filtered according to the ID of the user when logged into the content management system."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT #field_sql#
   FROM cache_occurrences o
   JOIN occurrences occ ON occ.id=o.id AND occ.deleted = FALSE

--- a/reports/library/samples/filterable_explore_list.xml
+++ b/reports/library/samples/filterable_explore_list.xml
@@ -2,7 +2,7 @@
     title="Explore samples using standard filters"
     description="Explore samples with standardised filtering parameters."
 >
-  <query website_filter_field="su.website_id" samples_id_field="s.id" standard_params="samples"
+  <query website_filter_field="su.website_id" standard_params="samples"
          created_by_field="s.created_by_id" training_filter_field="">
   SELECT #columns#
   FROM samples s

--- a/reports/library/samples/filterable_explore_list_mapping.xml
+++ b/reports/library/samples/filterable_explore_list_mapping.xml
@@ -2,7 +2,7 @@
     title="Explore samples using standard filters for mapping"
     description="Explore samples with standardised filtering parameters."
 >
-  <query website_filter_field="su.website_id" samples_id_field="s.id" standard_params="samples"
+  <query website_filter_field="su.website_id" standard_params="samples"
          created_by_field="s.created_by_id" training_filter_field="">
   SELECT #columns#
   FROM samples s

--- a/reports/library/samples/filterable_samples_download_gis.xml
+++ b/reports/library/samples/filterable_samples_download_gis.xml
@@ -2,7 +2,7 @@
     title="Samples download using standard filters for GIS"
     description="Download samples with standardised filtering parameters."
 >
-  <query website_filter_field="su.website_id" samples_id_field="s.id" standard_params="samples"
+  <query website_filter_field="su.website_id" standard_params="samples"
          created_by_field="s.created_by_id" training_filter_field="">
   SELECT #columns#
   FROM samples s

--- a/reports/library/taxa/explore_list.xml
+++ b/reports/library/taxa/explore_list.xml
@@ -2,7 +2,7 @@
     title="Explore distinct species"
     description="Report designed for species lists used in the explore records facility in iRecord. "
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT distinct #columns#
   FROM cache_occurrences o
   JOIN websites w on w.id=o.website_id 

--- a/reports/library/taxa/explore_list_2.xml
+++ b/reports/library/taxa/explore_list_2.xml
@@ -5,7 +5,7 @@
         Spatial Index Builder module to index the list of locations that users can set in their preferences
         as their locality, for significantly improved performance."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT distinct #columns#
   FROM cache_occurrences o
   JOIN websites w on w.id=o.website_id 

--- a/reports/library/taxa/explore_list_2_using_spatial_index_builder.xml
+++ b/reports/library/taxa/explore_list_2_using_spatial_index_builder.xml
@@ -5,7 +5,7 @@
         Spatial Index Builder module to index the list of locations that users can set in their preferences
         as their locality, for significantly improved performance."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT distinct #columns#
   FROM cache_occurrences o
   JOIN websites w on w.id=o.website_id 

--- a/reports/library/taxa/explore_list_3_using_spatial_index_builder.xml
+++ b/reports/library/taxa/explore_list_3_using_spatial_index_builder.xml
@@ -5,7 +5,7 @@
         Spatial Index Builder module to index the list of locations that users can set in their preferences
         as their locality, for significantly improved performance."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT distinct #columns#
   FROM cache_occurrences o
   JOIN websites w on w.id=o.website_id 

--- a/reports/library/taxa/explore_list_using_spatial_index_builder.xml
+++ b/reports/library/taxa/explore_list_using_spatial_index_builder.xml
@@ -4,7 +4,7 @@
         Spatial Index Builder module to index the list of locations that users can set in their preferences
         as their locality, for significantly improved performance."
 >
-  <query website_filter_field="o.website_id">
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id">
   SELECT distinct #columns#
   FROM cache_occurrences o
   JOIN websites w on w.id=o.website_id 


### PR DESCRIPTION
After recent performance revisions the o.sample_id field was being used
to join to get sample attributes which was not correct for pure sample
reports.