### PR TITLE
Corrected regular expression

### DIFF
--- a/modules/occurrence_associations/models/occurrence_association.php
+++ b/modules/occurrence_associations/models/occurrence_association.php
@@ -60,7 +60,7 @@ class Occurrence_association_Model extends ORM {
    */
   public function __set($key, $value)
   {
-    if (substr($key,-16) === 'to_occurrence_id' && preg_match('/^||.+||$/', $value))
+    if (substr($key,-16) === 'to_occurrence_id' && preg_match('/^\|\|.+\|\|$/', $value))
     {
       $this->to_occurrence_id_pointer = str_replace('||', '', $value);
       $value = null;


### PR DESCRIPTION
Resaving an association with known to_occurrence_id was not
working as the regex picked up standard integer foreign keys
and treated them as a pointer to a not-yet existing occurrence.