### PR TITLE
Report performance

### DIFF
--- a/reports/library/occurrences/nbn_exchange.xml
+++ b/reports/library/occurrences/nbn_exchange.xml
@@ -2,32 +2,31 @@
     title="NBN Exchange format"
     description="An extract of records in a format suitable for creating NBN Exchange format files in combination with the nbn output format."
 >
-  <query website_filter_field="co.website_id">
+  <query website_filter_field="o.website_id">
 select #columns#
-from cache_occurrences co
-join occurrences o on o.id=co.id -- ensure we have the latest status. Would not be needed if cache_occurrences reflects updated immediately
+from cache_occurrences o
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
   join cache_termlists_terms ctt on ctt.id=ils.location_type_id and ctt.term='Vice County'
-) on ils.sample_id=co.sample_id and ils.contains=true
+) on ils.sample_id=o.sample_id and ils.contains=true
 left join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
 #agreements_join#
 #joins#
 where #sharing_filter# 
-and co.date_type in ('D','DD','O','OO','Y','YY','-Y','U') 
-and (#ownData#=0 or CAST(co.created_by_id as character varying)='#currentUser#')
-and (s.entered_sref_system ilike 'osgb' or s.entered_sref_system ilike 'osie' or s.entered_sref_system = '4326' or s.entered_sref_system = '27700')
-and (trim('#date_from#')='' or '#date_from#'='Click here' or co.date_end &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date))
-and (trim('#date_to#')='' or '#date_to#'='Click here' or co.date_start &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date))            
-and quality_check('#quality#', co.record_status, co.certainty)=true
-and co.taxa_taxon_list_external_key is not null
+and o.date_type in ('D','DD','O','OO','Y','YY','-Y','U') 
+and (#ownData#=0 or CAST(o.created_by_id as character varying)='#currentUser#')
+and (o.entered_sref_system ilike 'osgb' or o.entered_sref_system ilike 'osie' or o.entered_sref_system = '4326' or o.entered_sref_system = '27700')
+and (trim('#date_from#')='' or '#date_from#'='Click here' or o.date_end &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date))
+and (trim('#date_to#')='' or '#date_to#'='Click here' or o.date_start &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date))            
+and quality_check('#quality#', o.record_status, o.certainty)=true
+and o.taxa_taxon_list_external_key is not null
 and st_x(st_transform(st_centroid(public_geom), 4326)) between -14 and 13
 and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
  
   </query>
   
   <order_bys>
-    <order_by>co.id ASC</order_by>
+    <order_by>o.id ASC</order_by>
   </order_bys>
   <params>
     <param name='date_from' display='Date From' datatype='date' description="Filter by record added or updated date" />
@@ -41,46 +40,46 @@ and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
     <param name='location_id' display='Location' description='Provide the location to display records for' datatype='lookup' emptyvalue="0"
         population_call='direct:location:id:name' />
     <param name="ownLocality" display="My locality only?" datatype="checkbox" emptyvalue="0">
-      <join value="1">JOIN locations lfilter ON st_intersects(lfilter.boundary_geom, co.public_geom) AND lfilter.id=#location_id#</join>  
+      <join value="1">JOIN locations lfilter ON st_intersects(lfilter.boundary_geom, o.public_geom) AND lfilter.id=#location_id#</join>  
     </param>
     <param name="taxon_groups" display="Taxon Groups" description="List of taxon group IDs to view data for" datatype="integer[]" emptyvalue="0"/>
     <param name="ownGroups" display="My species groups only?" datatype="checkbox">      
-      <join value="1">JOIN taxon_groups tgfilter ON tgfilter.id=co.taxon_group_id AND tgfilter.id IN (#taxon_groups#)</join>
+      <join value="1">JOIN taxon_groups tgfilter ON tgfilter.id=o.taxon_group_id AND tgfilter.id IN (#taxon_groups#)</join>
     </param>
     <param name="surveys" display="Surveys" description="List of survey IDs to view data for" datatype="integer[]" emptyvalue="0"/>
     <param name="ownSurveys" display="My surveys only?" datatype="checkbox">      
-      <join value="1">JOIN surveys su ON su.id=co.survey_id AND su.id IN (#surveys#)</join>
+      <join value="1">JOIN surveys su ON su.id=o.survey_id AND su.id IN (#surveys#)</join>
     </param>
   </params>
   <columns>
-    <column name='id' display='ID' sql="co.id" datatype="integer" visible="false" />
-    <column name='recordkey' display='RecordKey' sql="'iBRC' || co.id" datatype="text" />
-    <column name='surveykey' display='SurveyKey' sql='co.survey_id' datatype="integer" />
-    <column name='samplekey' display='SampleKey' sql='co.sample_id' datatype="integer" />
-    <column name='taxonversionkey' display='TaxonVersionKey' sql='co.taxa_taxon_list_external_key' datatype="text" />
-    <column name='zeroabundance' display='ZeroAbundance' sql='upper(cast (co.zero_abundance as character))' datatype="text" />
+    <column name='id' display='ID' sql="o.id" datatype="integer" visible="false" />
+    <column name='recordkey' display='RecordKey' sql="'iBRC' || o.id" datatype="text" />
+    <column name='surveykey' display='SurveyKey' sql='o.survey_id' datatype="integer" />
+    <column name='samplekey' display='SampleKey' sql='o.sample_id' datatype="integer" />
+    <column name='taxonversionkey' display='TaxonVersionKey' sql='o.taxa_taxon_list_external_key' datatype="text" />
+    <column name='zeroabundance' display='ZeroAbundance' sql='upper(cast (o.zero_abundance as character))' datatype="text" />
     <column name='sensitive' display='Sensitive' sql="case when o.sensitivity_precision is null then 'F' else 'T' end" datatype="text" />
-    <column name='startdate' display='StartDate' sql='cast(co.date_start as character varying)' datatype="text" />
-    <column name='enddate' display='EndDate' sql='cast(co.date_end as character varying)' datatype="text" />
-    <column name='datetype' display='DateType' sql='co.date_type' datatype="integer" />
-    <column name='sitekey' display='SiteKey' sql='s.location_id' datatype="integer" />
-    <column name='sitename' display='SiteName' sql='co.location_name' datatype="text" />
-    <column name='gridreference' display='GridReference' sql="case when s.entered_sref_system in ('4326', '27700') then null else replace(s.entered_sref, ' ', '') end" datatype="text" />
-    <column name='east' display='East' sql="case when s.entered_sref_system in ('4326', '27700') then st_x(st_transform(st_centroid(public_geom), s.entered_sref_system::int)) else null end" datatype="text" />
-    <column name='north' display='North' sql="case when s.entered_sref_system in ('4326', '27700') then st_y(st_transform(st_centroid(public_geom), s.entered_sref_system::int)) else null end" datatype="text" />
+    <column name='startdate' display='StartDate' sql='cast(o.date_start as character varying)' datatype="text" />
+    <column name='enddate' display='EndDate' sql='cast(o.date_end as character varying)' datatype="text" />
+    <column name='datetype' display='DateType' sql='o.date_type' datatype="integer" />
+    <column name='sitekey' display='SiteKey' sql='o.location_id' datatype="integer" />
+    <column name='sitename' display='SiteName' sql='o.location_name' datatype="text" />
+    <column name='gridreference' display='GridReference' sql="case when o.entered_sref_system in ('4326', '27700') then null else replace(s.entered_sref, ' ', '') end" datatype="text" />
+    <column name='east' display='East' sql="case when o.entered_sref_system in ('4326', '27700') then st_x(st_transform(st_centroid(public_geom), o.entered_sref_system::int)) else null end" datatype="text" />
+    <column name='north' display='North' sql="case when o.entered_sref_system in ('4326', '27700') then st_y(st_transform(st_centroid(public_geom), o.entered_sref_system::int)) else null end" datatype="text" />
     <column name='projection' display='Projection' 
-        sql="case upper(s.entered_sref_system) when '4326' then 'WGS84' when '27700' then 'OSGB36' when 'OSIE' then 'OSI' else upper(s.entered_sref_system) end" 
+        sql="case upper(o.entered_sref_system) when '4326' then 'WGS84' when '27700' then 'OSGB36' when 'OSIE' then 'OSI' else upper(o.entered_sref_system) end" 
         datatype="text" />
     <column name='precision' display='Precision' 
-        sql="case s.entered_sref_system
+        sql="case o.entered_sref_system
     when '4326' then 50 
     when '27700' then 1
     else case length(replace(s.entered_sref, ' ', '')) when 5 then 2000 else pow(10, (12-length(replace(s.entered_sref, ' ', '')))/2) end
   end" 
         datatype="text" />
     <column name="vicecounty" display="ViceCounty" sql="array_to_string(array_agg(l.name), ', ')" datatype="text" aggregate="true" />        
-    <column name='recorder' display='Recorder' sql='co.recorders' datatype="text" />
-    <column name='verifier' display='Verifier' sql='co.verifier' datatype="text" />
+    <column name='recorder' display='Recorder' sql='o.recorders' datatype="text" />
+    <column name='verifier' display='Verifier' sql='o.verifier' datatype="text" />
         
   </columns>
 </report>

--- a/reports/library/occurrences/nbn_exchange_by_input_date.xml
+++ b/reports/library/occurrences/nbn_exchange_by_input_date.xml
@@ -2,34 +2,33 @@
     title="NBN Exchange format by input date"
     description="An extract of records in a format suitable for creating NBN Exchange format files in combination with the nbn output format, filtered by input date."
 >
-  <query website_filter_field="co.website_id">
+  <query website_filter_field="o.website_id">
 select #columns#
-from cache_occurrences co
-join occurrences o on o.id=co.id -- ensure we have the latest status. Would not be needed if cache_occurrences reflects updated immediately
+from cache_occurrences o
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
   join cache_termlists_terms ctt on ctt.id=ils.location_type_id and ctt.term='Vice County'
-) on ils.sample_id=co.sample_id and ils.contains=true
+) on ils.sample_id=o.sample_id and ils.contains=true
 left join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
 #agreements_join#
 #joins#
 where #sharing_filter# 
-and co.date_type in ('D','DD','O','OO','Y','YY','-Y','U') 
-and (#ownData#=0 or CAST(co.created_by_id as character varying)='#currentUser#')
-and (s.entered_sref_system ilike 'osgb' or s.entered_sref_system ilike 'osie' or s.entered_sref_system = '4326' or s.entered_sref_system = '27700')
+and o.date_type in ('D','DD','O','OO','Y','YY','-Y','U') 
+and (#ownData#=0 or CAST(o.created_by_id as character varying)='#currentUser#')
+and (o.entered_sref_system ilike 'osgb' or o.entered_sref_system ilike 'osie' or o.entered_sref_system = '4326' or o.entered_sref_system = '27700')
 and (trim('#date_from#')='' or '#date_from#'='Click here' 
-    or o.created_on &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date) or o.updated_on &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date) )
+    or o.cache_created_on &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date) or o.cache_updated_on &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date) )
 and (trim('#date_to#')='' or '#date_to#'='Click here' 
-    or o.created_on &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date) or o.updated_on &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date) )
-and quality_check('#quality#', co.record_status, co.certainty)=true
-and co.taxa_taxon_list_external_key is not null
+    or o.cache_created_on &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date) or o.cache_updated_on &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date) )
+and quality_check('#quality#', o.record_status, o.certainty)=true
+and o.taxa_taxon_list_external_key is not null
 and st_x(st_transform(st_centroid(public_geom), 4326)) between -14 and 13
 and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
  
   </query>
   
   <order_bys>
-    <order_by>co.id ASC</order_by>
+    <order_by>o.id ASC</order_by>
   </order_bys>
   <params>
     <param name='date_from' display='Date From' datatype='date' description="Filter by record added or updated date" />
@@ -43,46 +42,45 @@ and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
     <param name='location_id' display='Location' description='Provide the location to display records for' datatype='lookup' emptyvalue="0"
         population_call='direct:location:id:name' />
     <param name="ownLocality" display="My locality only?" datatype="checkbox">
-      <join value="1">JOIN locations lfilter ON st_intersects(lfilter.boundary_geom, co.public_geom) AND lfilter.id=#location_id#</join>  
+      <join value="1">JOIN locations lfilter ON st_intersects(lfilter.boundary_geom, o.public_geom) AND lfilter.id=#location_id#</join>  
     </param>
     <param name="taxon_groups" display="Taxon Groups" description="List of taxon group IDs to view data for" datatype="integer[]" emptyvalue="0"/>
     <param name="ownGroups" display="My species groups only?" datatype="checkbox">      
-      <join value="1">JOIN taxon_groups tgfilter ON tgfilter.id=co.taxon_group_id AND tgfilter.id IN (#taxon_groups#)</join>
+      <join value="1">JOIN taxon_groups tgfilter ON tgfilter.id=o.taxon_group_id AND tgfilter.id IN (#taxon_groups#)</join>
     </param>
     <param name="surveys" display="Surveys" description="List of survey IDs to view data for" datatype="integer[]" emptyvalue="0"/>
     <param name="ownSurveys" display="My surveys only?" datatype="checkbox">      
-      <join value="1">JOIN surveys su ON su.id=co.survey_id AND su.id IN (#surveys#)</join>
+      <join value="1">JOIN surveys su ON su.id=o.survey_id AND su.id IN (#surveys#)</join>
     </param>
   </params>
   <columns>
-    <column name='id' display='ID' sql="co.id" datatype="integer" visible="false" />
-    <column name='recordkey' display='RecordKey' sql="'iBRC' || co.id" datatype="text" />
-    <column name='surveykey' display='SurveyKey' sql='co.survey_id' datatype="integer" />
-    <column name='samplekey' display='SampleKey' sql='co.sample_id' datatype="integer" />
-    <column name='taxonversionkey' display='TaxonVersionKey' sql='co.taxa_taxon_list_external_key' datatype="text" />
-    <column name='zeroabundance' display='ZeroAbundance' sql='upper(cast (co.zero_abundance as character))' datatype="text" />
+    <column name='id' display='ID' sql="o.id" datatype="integer" visible="false" />
+    <column name='recordkey' display='RecordKey' sql="'iBRC' || o.id" datatype="text" />
+    <column name='surveykey' display='SurveyKey' sql='o.survey_id' datatype="integer" />
+    <column name='samplekey' display='SampleKey' sql='o.sample_id' datatype="integer" />
+    <column name='taxonversionkey' display='TaxonVersionKey' sql='o.taxa_taxon_list_external_key' datatype="text" />
+    <column name='zeroabundance' display='ZeroAbundance' sql='upper(cast (o.zero_abundance as character))' datatype="text" />
     <column name='sensitive' display='Sensitive' sql="case when o.sensitivity_precision is null then 'F' else 'T' end" datatype="text" />
-    <column name='startdate' display='StartDate' sql='cast(co.date_start as character varying)' datatype="text" />
-    <column name='enddate' display='EndDate' sql='cast(co.date_end as character varying)' datatype="text" />
-    <column name='datetype' display='DateType' sql='co.date_type' datatype="integer" />
-    <column name='sitekey' display='SiteKey' sql='s.location_id' datatype="integer" />
-    <column name='sitename' display='SiteName' sql='co.location_name' datatype="text" />
-    <column name='gridreference' display='GridReference' sql="case when s.entered_sref_system in ('4326', '27700') then null else replace(s.entered_sref, ' ', '') end" datatype="text" />
-    <column name='east' display='East' sql="case when s.entered_sref_system in ('4326', '27700') then st_x(st_transform(st_centroid(public_geom), s.entered_sref_system::int)) else null end" datatype="text" />
-    <column name='north' display='North' sql="case when s.entered_sref_system in ('4326', '27700') then st_y(st_transform(st_centroid(public_geom), s.entered_sref_system::int)) else null end" datatype="text" />
+    <column name='startdate' display='StartDate' sql='cast(o.date_start as character varying)' datatype="text" />
+    <column name='enddate' display='EndDate' sql='cast(o.date_end as character varying)' datatype="text" />
+    <column name='datetype' display='DateType' sql='o.date_type' datatype="integer" />
+    <column name='sitekey' display='SiteKey' sql='o.location_id' datatype="integer" />
+    <column name='sitename' display='SiteName' sql='o.location_name' datatype="text" />
+    <column name='gridreference' display='GridReference' sql="case when o.entered_sref_system in ('4326', '27700') then null else replace(s.entered_sref, ' ', '') end" datatype="text" />
+    <column name='east' display='East' sql="case when o.entered_sref_system in ('4326', '27700') then st_x(st_transform(st_centroid(public_geom), o.entered_sref_system::int)) else null end" datatype="text" />
+    <column name='north' display='North' sql="case when o.entered_sref_system in ('4326', '27700') then st_y(st_transform(st_centroid(public_geom), o.entered_sref_system::int)) else null end" datatype="text" />
     <column name='projection' display='Projection' 
-        sql="case upper(s.entered_sref_system) when '4326' then 'WGS84' when '27700' then 'OSGB36' when 'OSIE' then 'OSI' else upper(s.entered_sref_system) end" 
+        sql="case upper(o.entered_sref_system) when '4326' then 'WGS84' when '27700' then 'OSGB36' when 'OSIE' then 'OSI' else upper(o.entered_sref_system) end" 
         datatype="text" />
     <column name='precision' display='Precision' 
-        sql="case s.entered_sref_system
+        sql="case o.entered_sref_system
     when '4326' then 50 
     when '27700' then 1
     else case length(replace(s.entered_sref, ' ', '')) when 5 then 2000 else pow(10, (12-length(replace(s.entered_sref, ' ', '')))/2) end
   end" 
         datatype="text" />
     <column name="vicecounty" display="ViceCounty" sql="array_to_string(array_agg(l.name), ', ')" datatype="text" aggregate="true" />        
-    <column name='recorder' display='Recorder' sql='co.recorders' datatype="text" />
-    <column name='verifier' display='Verifier' sql='co.verifier' datatype="text" />
-        
+    <column name='recorder' display='Recorder' sql='o.recorders' datatype="text" />
+    <column name='verifier' display='Verifier' sql='o.verifier' datatype="text" />
   </columns>
 </report>

--- a/reports/library/occurrences/nbn_exchange_by_input_date_using_spatial_index_builder.xml
+++ b/reports/library/occurrences/nbn_exchange_by_input_date_using_spatial_index_builder.xml
@@ -3,34 +3,33 @@
     description="An extract of records in a format suitable for creating NBN Exchange format files in combination with the nbn output format, filtered by input date.
         Requires the spatial index builder for location filters."
 >
-  <query website_filter_field="co.website_id">
+  <query website_filter_field="o.website_id">
 select #columns#
-from cache_occurrences co
-join occurrences o on o.id=co.id -- ensure we have the latest status. Would not be needed if cache_occurrences reflects updated immediately
+from cache_occurrences o
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
   join cache_termlists_terms ctt on ctt.id=ils.location_type_id and ctt.term='Vice County'
-) on ils.sample_id=co.sample_id and ils.contains=true
+) on ils.sample_id=o.sample_id and ils.contains=true
 left join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
 #agreements_join#
 #joins#
 where #sharing_filter# 
-and co.date_type in ('D','DD','O','OO','Y','YY','-Y','U') 
-and (#ownData#=0 or CAST(co.created_by_id as character varying)='#currentUser#')
-and (s.entered_sref_system ilike 'osgb' or s.entered_sref_system ilike 'osie' or s.entered_sref_system = '4326' or s.entered_sref_system = '27700')
+and o.date_type in ('D','DD','O','OO','Y','YY','-Y','U') 
+and (#ownData#=0 or CAST(o.created_by_id as character varying)='#currentUser#')
+and (o.entered_sref_system ilike 'osgb' or o.entered_sref_system ilike 'osie' or o.entered_sref_system = '4326' or o.entered_sref_system = '27700')
 and (trim('#date_from#')='' or '#date_from#'='Click here' 
-    or o.created_on &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date) or o.updated_on &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date) )
+    or o.cache_created_on &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date) or o.cache_updated_on &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date) )
 and (trim('#date_to#')='' or '#date_to#'='Click here' 
-    or o.created_on &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date) or o.updated_on &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date) )
-and quality_check('#quality#', co.record_status, co.certainty)=true
-and co.taxa_taxon_list_external_key is not null
-and st_x(st_transform(st_centroid(public_geom), 4326)) between -14 and 13
-and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
+    or o.cache_created_on &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date) or o.cache_updated_on &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date) )
+and quality_check('#quality#', o.record_status, o.certainty)=true
+and o.taxa_taxon_list_external_key is not null
+and st_x(st_transform(st_centroid(o.public_geom), 4326)) between -14 and 13
+and st_y(st_transform(st_centroid(o.public_geom), 4326)) between 48 and 62
  
   </query>
   
   <order_bys>
-    <order_by>co.id ASC</order_by>
+    <order_by>o.id ASC</order_by>
   </order_bys>
   <params>
     <param name='date_from' display='Date From' datatype='date' description="Filter by record added or updated date" />
@@ -48,42 +47,42 @@ and st_y(st_transform(st_centroid(public_geom), 4326)) between 48 and 62
     </param>
     <param name="taxon_groups" display="Taxon Groups" description="List of taxon group IDs to view data for" datatype="integer[]" emptyvalue="0"/>
     <param name="ownGroups" display="My species groups only?" datatype="checkbox">      
-      <join value="1">JOIN taxon_groups tgfilter ON tgfilter.id=co.taxon_group_id AND tgfilter.id IN (#taxon_groups#)</join>
+      <join value="1">JOIN taxon_groups tgfilter ON tgfilter.id=o.taxon_group_id AND tgfilter.id IN (#taxon_groups#)</join>
     </param>
     <param name="surveys" display="Surveys" description="List of survey IDs to view data for" datatype="integer[]" emptyvalue="0"/>
     <param name="ownSurveys" display="My surveys only?" datatype="checkbox">      
-      <join value="1">JOIN surveys su ON su.id=co.survey_id AND su.id IN (#surveys#)</join>
+      <join value="1">JOIN surveys su ON su.id=o.survey_id AND su.id IN (#surveys#)</join>
     </param>
   </params>
   <columns>
-    <column name='id' display='ID' sql="co.id" datatype="integer" visible="false" />
-    <column name='recordkey' display='RecordKey' sql="'iBRC' || co.id" datatype="text" />
-    <column name='surveykey' display='SurveyKey' sql='co.survey_id' datatype="integer" />
-    <column name='samplekey' display='SampleKey' sql='co.sample_id' datatype="integer" />
-    <column name='taxonversionkey' display='TaxonVersionKey' sql='co.taxa_taxon_list_external_key' datatype="text" />
-    <column name='zeroabundance' display='ZeroAbundance' sql='upper(cast (co.zero_abundance as character))' datatype="text" />
+    <column name='id' display='ID' sql="o.id" datatype="integer" visible="false" />
+    <column name='recordkey' display='RecordKey' sql="'iBRC' || o.id" datatype="text" />
+    <column name='surveykey' display='SurveyKey' sql='o.survey_id' datatype="integer" />
+    <column name='samplekey' display='SampleKey' sql='o.sample_id' datatype="integer" />
+    <column name='taxonversionkey' display='TaxonVersionKey' sql='o.taxa_taxon_list_external_key' datatype="text" />
+    <column name='zeroabundance' display='ZeroAbundance' sql='upper(cast (o.zero_abundance as character))' datatype="text" />
     <column name='sensitive' display='Sensitive' sql="case when o.sensitivity_precision is null then 'F' else 'T' end" datatype="text" />
-    <column name='startdate' display='StartDate' sql='cast(co.date_start as character varying)' datatype="text" />
-    <column name='enddate' display='EndDate' sql='cast(co.date_end as character varying)' datatype="text" />
-    <column name='datetype' display='DateType' sql='co.date_type' datatype="integer" />
-    <column name='sitekey' display='SiteKey' sql='s.location_id' datatype="integer" />
-    <column name='sitename' display='SiteName' sql='co.location_name' datatype="text" />
-    <column name='gridreference' display='GridReference' sql="case when s.entered_sref_system in ('4326', '27700') then null else replace(s.entered_sref, ' ', '') end" datatype="text" />
-    <column name='east' display='East' sql="case when s.entered_sref_system in ('4326', '27700') then st_x(st_transform(st_centroid(public_geom), s.entered_sref_system::int)) else null end" datatype="text" />
-    <column name='north' display='North' sql="case when s.entered_sref_system in ('4326', '27700') then st_y(st_transform(st_centroid(public_geom), s.entered_sref_system::int)) else null end" datatype="text" />
+    <column name='startdate' display='StartDate' sql='cast(o.date_start as character varying)' datatype="text" />
+    <column name='enddate' display='EndDate' sql='cast(o.date_end as character varying)' datatype="text" />
+    <column name='datetype' display='DateType' sql='o.date_type' datatype="integer" />
+    <column name='sitekey' display='SiteKey' sql='o.location_id' datatype="integer" />
+    <column name='sitename' display='SiteName' sql='o.location_name' datatype="text" />
+    <column name='gridreference' display='GridReference' sql="case when o.entered_sref_system in ('4326', '27700') then null else replace(s.entered_sref, ' ', '') end" datatype="text" />
+    <column name='east' display='East' sql="case when o.entered_sref_system in ('4326', '27700') then st_x(st_transform(st_centroid(public_geom), o.entered_sref_system::int)) else null end" datatype="text" />
+    <column name='north' display='North' sql="case when o.entered_sref_system in ('4326', '27700') then st_y(st_transform(st_centroid(public_geom), o.entered_sref_system::int)) else null end" datatype="text" />
     <column name='projection' display='Projection' 
-        sql="case upper(s.entered_sref_system) when '4326' then 'WGS84' when '27700' then 'OSGB36' when 'OSIE' then 'OSI' else upper(s.entered_sref_system) end" 
+        sql="case upper(o.entered_sref_system) when '4326' then 'WGS84' when '27700' then 'OSGB36' when 'OSIE' then 'OSI' else upper(o.entered_sref_system) end" 
         datatype="text" />
     <column name='precision' display='Precision' 
-        sql="case s.entered_sref_system
+        sql="case o.entered_sref_system
     when '4326' then 50 
     when '27700' then 1
     else case length(replace(s.entered_sref, ' ', '')) when 5 then 2000 else pow(10, (12-length(replace(s.entered_sref, ' ', '')))/2) end
   end" 
         datatype="text" />
     <column name="vicecounty" display="ViceCounty" sql="array_to_string(array_agg(l.name), ', ')" datatype="text" aggregate="true" />        
-    <column name='recorder' display='Recorder' sql='co.recorders' datatype="text" />
-    <column name='verifier' display='Verifier' sql='co.verifier' datatype="text" />
+    <column name='recorder' display='Recorder' sql='o.recorders' datatype="text" />
+    <column name='verifier' display='Verifier' sql='o.verifier' datatype="text" />
         
   </columns>
 </report>


### PR DESCRIPTION
Older versions of NBN download reports tidied to remove unnecessary join
to occurrences table, plus filters use the cache_occurrences table where
possible.