### PR TITLE
Report download duplicate fixes

### DIFF
--- a/reports/library/occurrences/filterable_nbn_exchange.xml
+++ b/reports/library/occurrences/filterable_nbn_exchange.xml
@@ -8,8 +8,8 @@ from cache_occurrences o
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
   join cache_termlists_terms ctt on ctt.id=ils.location_type_id and ctt.term='Vice County'
+  join locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
 ) on ils.sample_id=o.sample_id and ils.contains=true
-left join locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
 left join groups g1 on g1.id=o.group_id and g1.deleted=false
 left join group_relations grel on grel.to_group_id=g1.id and grel.deleted=false
 left join groups g2 on g2.id=grel.from_group_id and g2.deleted=false

--- a/reports/library/occurrences/filterable_occurrences_download.xml
+++ b/reports/library/occurrences/filterable_occurrences_download.xml
@@ -10,8 +10,8 @@
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
     JOIN cache_termlists_terms ctt on ctt.id=ils.location_type_id AND ctt.term='Vice County'
+    JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
   ) on ils.sample_id=o.sample_id and ils.contains=true
-  LEFT JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
   LEFT JOIN (occurrence_attribute_values det_full_val
     JOIN occurrence_attributes det_full on det_full.id=det_full_val.occurrence_attribute_id and det_full.deleted=false and det_full.system_function='det_full_name'
   ) ON det_full_val.occurrence_id=o.id AND det_full_val.deleted=false

--- a/reports/library/occurrences/filterable_occurrences_download_gis.xml
+++ b/reports/library/occurrences/filterable_occurrences_download_gis.xml
@@ -9,8 +9,8 @@
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
     JOIN cache_termlists_terms ctt on ctt.id=ils.location_type_id AND ctt.term='Vice County'
+    JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
   ) on ils.sample_id=o.sample_id and ils.contains=true
-  LEFT JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
   LEFT JOIN (occurrence_attribute_values det_full_val
     JOIN occurrence_attributes det_full on det_full.id=det_full_val.occurrence_attribute_id and det_full.deleted=false and det_full.system_function='det_full_name'
   ) ON det_full_val.occurrence_id=o.id AND det_full_val.deleted=false

--- a/reports/library/occurrences/filterable_occurrences_download_parent_samples.xml
+++ b/reports/library/occurrences/filterable_occurrences_download_parent_samples.xml
@@ -10,8 +10,8 @@
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
     JOIN cache_termlists_terms ctt on ctt.id=ils.location_type_id AND ctt.term='Vice County'
+    JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
   ) on ils.sample_id=o.sample_id and ils.contains=true
-  LEFT JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
   LEFT JOIN (occurrence_attribute_values det_full_val
     JOIN occurrence_attributes det_full on det_full.id=det_full_val.occurrence_attribute_id and det_full.deleted=false and det_full.system_function='det_full_name'
   ) ON det_full_val.occurrence_id=o.id AND det_full_val.deleted=false

--- a/reports/library/occurrences/filterable_occurrences_download_sensitive.xml
+++ b/reports/library/occurrences/filterable_occurrences_download_sensitive.xml
@@ -10,8 +10,8 @@
   JOIN samples s on s.id=o.sample_id AND s.deleted=false
   LEFT JOIN (index_locations_samples ils
     JOIN cache_termlists_terms ctt on ctt.id=ils.location_type_id AND ctt.term='Vice County'
+    JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
   ) on ils.sample_id=o.sample_id and ils.contains=true
-  LEFT JOIN locations vc on vc.id=ils.location_id and coalesce(vc.code, '') not like '%+%'
   LEFT JOIN (occurrence_attribute_values det_full_val
     JOIN occurrence_attributes det_full on det_full.id=det_full_val.occurrence_attribute_id and det_full.deleted=false and det_full.system_function='det_full_name'
   ) ON det_full_val.occurrence_id=o.id AND det_full_val.deleted=false

--- a/reports/library/occurrences/nbn_exchange.xml
+++ b/reports/library/occurrences/nbn_exchange.xml
@@ -8,8 +8,8 @@ from cache_occurrences o
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
   join cache_termlists_terms ctt on ctt.id=ils.location_type_id and ctt.term='Vice County'
+  join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
 ) on ils.sample_id=o.sample_id and ils.contains=true
-left join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
 #agreements_join#
 #joins#
 where #sharing_filter# 

--- a/reports/library/occurrences/nbn_exchange_by_input_date.xml
+++ b/reports/library/occurrences/nbn_exchange_by_input_date.xml
@@ -8,8 +8,8 @@ from cache_occurrences o
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
   join cache_termlists_terms ctt on ctt.id=ils.location_type_id and ctt.term='Vice County'
+  join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
 ) on ils.sample_id=o.sample_id and ils.contains=true
-left join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
 #agreements_join#
 #joins#
 where #sharing_filter# 

--- a/reports/library/occurrences/nbn_exchange_by_input_date_using_spatial_index_builder.xml
+++ b/reports/library/occurrences/nbn_exchange_by_input_date_using_spatial_index_builder.xml
@@ -9,8 +9,8 @@ from cache_occurrences o
 join samples s on s.id=o.sample_id
 left join (index_locations_samples ils
   join cache_termlists_terms ctt on ctt.id=ils.location_type_id and ctt.term='Vice County'
+  join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
 ) on ils.sample_id=o.sample_id and ils.contains=true
-left join locations l on l.id=ils.location_id and coalesce(l.code, '') not like '%+%'
 #agreements_join#
 #joins#
 where #sharing_filter# 


### PR DESCRIPTION
Fixes a problem where a record which overlaps with a genuine vice county as well as a "fake supercounty" like Yorkshire or Sussex would get
included twice in download reports.