### PR TITLE
Updated/edit date filters work to second granularity

### DIFF
--- a/application/helpers/report_standard_params_occurrences.php
+++ b/application/helpers/report_standard_params_occurrences.php
@@ -149,13 +149,15 @@ class report_standard_params_occurrences {
       'input_date_from' => array('datatype'=>'date', 'default'=>'', 'display'=>'Input date from',
         'description'=>'Input date of first record to include in the output',
         'wheres' => array(
-          array('value'=>'', 'operator'=>'', 'sql'=>"('#input_date_from#'='Click here' OR o.cache_created_on >= CAST('#input_date_from#' as date))")
+          array('value'=>'', 'operator'=>'', 
+            'sql'=>"('#input_date_from#'='Click here' OR o.cache_created_on >= '#input_date_from#'::timestamp)")
         )
       ),
       'input_date_to' => array('datatype'=>'date', 'default'=>'', 'display'=>'Input date to',
         'description'=>'Input date of last record to include in the output',
         'wheres' => array(
-          array('value'=>'', 'operator'=>'', 'sql'=>"('#input_date_to#'='Click here' OR o.cache_created_on < CAST('#input_date_to#' as date)+'1 day'::interval)")
+          array('value'=>'', 'operator'=>'', 
+            'sql'=>"('#input_date_to#'='Click here' OR (o.cache_created_on <= '#input_date_to#'::timestamp OR (length('#input_date_to#')<=10 AND o.cache_created_on < cast('#input_date_to#' as date) + '1 day'::interval)))")
         )
       ),
       'input_date_age' => array('datatype'=>'text', 'default'=>'', 'display'=>'Input date from time ago',
@@ -167,13 +169,15 @@ class report_standard_params_occurrences {
       'edited_date_from' => array('datatype'=>'date', 'default'=>'', 'display'=>'Last update date from',
         'description'=>'Last update date of first record to include in the output',
         'wheres' => array(
-          array('value'=>'', 'operator'=>'', 'sql'=>"('#edited_date_from#'='Click here' OR o.cache_updated_on >= CAST('#edited_date_from#' as date))")
+          array('value'=>'', 'operator'=>'', 
+            'sql'=>"('#edited_date_from#'='Click here' OR o.cache_updated_on >= '#edited_date_from#'::timestamp)")
         )
       ),
       'edited_date_to' => array('datatype'=>'date', 'default'=>'', 'display'=>'Last update date to',
         'description'=>'Last update date of last record to include in the output',
         'wheres' => array(
-          array('value'=>'', 'operator'=>'', 'sql'=>"('#edited_date_to#'='Click here' OR o.cache_updated_on < CAST('#edited_date_to#' as date)+'1 day'::interval)")
+          array('value'=>'', 'operator'=>'', 
+            'sql'=>"('#edited_date_to#'='Click here' OR (o.cache_updated_on <= '#edited_date_to#'::timestamp OR (length('#edited_date_to#')<=10 AND o.cache_updated_on < cast('#input_date_to#' as date) + '1 day'::interval)))")
         )
       ),
       'edited_date_age' => array('datatype'=>'text', 'default'=>'', 'display'=>'Last update date from time ago',

--- a/application/helpers/report_standard_params_samples.php
+++ b/application/helpers/report_standard_params_samples.php
@@ -139,14 +139,14 @@ class report_standard_params_samples {
       ),
       'input_date_from' => array('datatype'=>'date', 'default'=>'', 'display'=>'Input date from',
         'description'=>'Input date of first sample to include in the output',
-        'wheres' => array(
-          array('value'=>'', 'operator'=>'', 'sql'=>"('#input_date_from#'='Click here' OR s.created_on >= CAST('#input_date_from#' as date))")
+        'wheres' =>array('value'=>'', 'operator'=>'', 
+            'sql'=>"('#input_date_from#'='Click here' OR s.created_on >= '#input_date_from#'::timestamp)")
         )
       ),
       'input_date_to' => array('datatype'=>'date', 'default'=>'', 'display'=>'Input date to',
         'description'=>'Input date of last sample to include in the output',
-        'wheres' => array(
-          array('value'=>'', 'operator'=>'', 'sql'=>"('#input_date_to#'='Click here' OR s.created_on < CAST('#input_date_to#' as date)+'1 day'::interval)")
+        'wheres' => array('value'=>'', 'operator'=>'', 
+            'sql'=>"('#input_date_to#'='Click here' OR (s.created_on <= '#input_date_to#'::timestamp OR (length('#input_date_to#')<=10 AND s.created_on < cast('#input_date_to#' as date) + '1 day'::interval)))")
         )
       ),
       'input_date_age' => array('datatype'=>'text', 'default'=>'', 'display'=>'Input date from time ago',
@@ -157,14 +157,14 @@ class report_standard_params_samples {
       ),
       'edited_date_from' => array('datatype'=>'date', 'default'=>'', 'display'=>'Last update date from',
         'description'=>'Last update date of first sample to include in the output',
-        'wheres' => array(
-          array('value'=>'', 'operator'=>'', 'sql'=>"('#edited_date_from#'='Click here' OR s.updated_on >= CAST('#edited_date_from#' as date))")
+        'wheres' =>array('value'=>'', 'operator'=>'', 
+            'sql'=>"('#edited_date_from#'='Click here' OR s.updated_on >= '#edited_date_from#'::timestamp)")
         )
       ),
       'edited_date_to' => array('datatype'=>'date', 'default'=>'', 'display'=>'Last update date to',
         'description'=>'Last update date of last sample to include in the output',
-        'wheres' => array(
-          array('value'=>'', 'operator'=>'', 'sql'=>"('#edited_date_to#'='Click here' OR s.updated_on < CAST('#edited_date_to#' as date)+'1 day'::interval)")
+        'wheres' => array('value'=>'', 'operator'=>'', 
+            'sql'=>"('#edited_date_to#'='Click here' OR (s.updated_on <= '#edited_date_to#'::timestamp OR (length('#edited_date_to#')<=10 AND s.updated_on < cast('#edited_date_to#' as date) + '1 day'::interval)))")
         )
       ),
       'edited_date_age' => array('datatype'=>'text', 'default'=>'', 'display'=>'Last update date from time ago',


### PR DESCRIPTION
Standard params filters on created or updated dates of occurrences and
samples used to only work to day granularity. If a day is supplied as
the filter it still works the same way, but you can now specify hh:mm:ss
as well to filter to second granularity.