### PR TITLE
Added a can_edit column to occurrences associations list report

### DIFF
--- a/modules/occurrence_associations/reports/library/occurrence_associations/filterable_explore_list.xml
+++ b/modules/occurrence_associations/reports/library/occurrence_associations/filterable_explore_list.xml
@@ -63,6 +63,8 @@
     <column name='certainty' display='Certainty' sql='o.certainty' visible="false" />
     <column name='belongs_to_user' display='Belongs to user' sql="CASE WHEN CAST(o.created_by_id AS character varying) = '#user_id#' AND o.website_id IN (#website_ids#) THEN true ELSE false END" visible="false" />
     <column name='belongs_to_site' display='Belongs to site' sql="CASE WHEN o.website_id IN (#website_ids#) THEN true ELSE false END" visible="false" />
+    <column name='can_edit' display='Can edit' 
+      sql="CASE WHEN CAST(o.created_by_id AS character varying) = '#user_id#' AND o.website_id IN (#website_ids#) and (oa.from_occurrence_id=o.id or oa.from_occurrence_id is null) THEN true ELSE false END" visible="false" />
     <column name='images' display='Images' sql='o.images' img='true' />
     <column name='input_form' visible="false" sql="case when o.input_form is null then '#default_input_form#' else o.input_form end" datatype="text" />
     <column name='pass' visible='false' sql="CASE WHEN o.data_cleaner_info='pass' THEN '&lt;div class=&quot;pass-icon&quot; title=&quot;This record passes all automated verification checks.&quot;/&gt;&lt;/div&gt;' WHEN not w.verification_checks_enabled THEN '&lt;div title=&quot;This record is not included in the automated verification check system.&quot;/&gt;-&lt;/div&gt;' END" />


### PR DESCRIPTION
This tags records on the "left" side of associations as editable, as
those on the "right" side are entered into the same form so shouldn't be
accessed directly on the edit page. Therefore you can use the output of
this field to control the visibililty of edit actions in report grids.