### PR TITLE
Corrected SRID for German MTB reference system

### DIFF
--- a/modules/indicia_setup/db/version_0_9_1/201603132027_sref_system_to_srid.sql
+++ b/modules/indicia_setup/db/version_0_9_1/201603132027_sref_system_to_srid.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION sref_system_to_srid(sref_system character varying)
+  RETURNS integer AS
+$BODY$
+  BEGIN
+    RETURN CASE lower(sref_system)
+           WHEN 'osgb' THEN 27700
+           WHEN 'osie' THEN 29901
+           WHEN 'lugr' THEN 2169
+           WHEN 'mtbqqq' THEN 4314
+           WHEN 'guernsey' THEN 3108
+           WHEN 'jersey' THEN 3109
+           WHEN 'utm30ed50' THEN 23030
+           WHEN 'utm30wgs84' THEN 32630
+           ELSE sref_system :: INTEGER
+           END;
+  END;
+  $BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;

--- a/modules/sref_mtb/plugins/sref_mtb.php
+++ b/modules/sref_mtb/plugins/sref_mtb.php
@@ -27,7 +27,7 @@
 function sref_mtb_sref_systems() {
   return array('mtbqqq' => array(
     'title' => 'Messtischblattquadranten',
-    'srid' => 4745,
+    'srid' => 4314,
     'treat_srid_as_x_y_metres' => false
   ));
 }


### PR DESCRIPTION
Should be 4314, not 4745 which only covers part of east Germany.