### PR TITLE
Uploads: fetching of sample_method or location_type specific attributes as field options

### DIFF
--- a/application/models/location.php
+++ b/application/models/location.php
@@ -178,8 +178,8 @@ class Location_Model extends ORM_Tree {
     $systems = spatial_ref::system_metadata();
     foreach ($systems as $code=>$metadata)
       $srefs[] = str_replace(array(',',':'), array('&#44', '&#56'), $code) .
-    				":".
-    				str_replace(array(',',':'), array('&#44', '&#56'), $metadata['title']);
+          ":".
+          str_replace(array(',',':'), array('&#44', '&#56'), $metadata['title']);
     	 
     return array(
       'website_id' => array( 

--- a/application/models/location.php
+++ b/application/models/location.php
@@ -176,8 +176,11 @@ class Location_Model extends ORM_Tree {
   public function fixed_values_form() {
     $srefs = array();
     $systems = spatial_ref::system_metadata();
-    foreach ($systems as $code=>$metadata) 
-      $srefs[] = "$code:".$metadata['title'];
+    foreach ($systems as $code=>$metadata)
+      $srefs[] = str_replace(array(',',':'), array('&#44', '&#56'), $code) .
+    				":".
+    				str_replace(array(',',':'), array('&#44', '&#56'), $metadata['title']);
+    	 
     return array(
       'website_id' => array( 
         'display'=>'Website', 

--- a/application/models/occurrence.php
+++ b/application/models/occurrence.php
@@ -427,8 +427,10 @@ class Occurrence_Model extends ORM
   public function fixed_values_form() {
     $srefs = array();
     $systems = spatial_ref::system_list();
-    foreach ($systems as $code=>$title) 
-      $srefs[] = "$code:$title";
+    foreach ($systems as $code=>$title)
+    	$srefs[] = str_replace(array(',',':'), array('&#44', '&#56'), $code) .
+    				":".
+    				str_replace(array(',',':'), array('&#44', '&#56'), $title);
     return array(
       'website_id' => array( 
         'display'=>'Website', 

--- a/application/models/occurrence.php
+++ b/application/models/occurrence.php
@@ -429,8 +429,8 @@ class Occurrence_Model extends ORM
     $systems = spatial_ref::system_list();
     foreach ($systems as $code=>$title)
     	$srefs[] = str_replace(array(',',':'), array('&#44', '&#56'), $code) .
-    				":".
-    				str_replace(array(',',':'), array('&#44', '&#56'), $title);
+          ":".
+          str_replace(array(',',':'), array('&#44', '&#56'), $title);
     return array(
       'website_id' => array( 
         'display'=>'Website', 

--- a/application/models/sample.php
+++ b/application/models/sample.php
@@ -270,17 +270,23 @@ class Sample_Model extends ORM_Tree
     $srefs = array();
     $systems = spatial_ref::system_list();
     foreach ($systems as $code=>$title) 
-      $srefs[] = "$code:$title";
+    	$srefs[] = str_replace(array(',',':'), array('&#44', '&#56'), $code) .
+    				":".
+    				str_replace(array(',',':'), array('&#44', '&#56'), $title);
     
     $sample_methods = array(":Defined in file");
     $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:sample_methods')->orderby('term', 'asc')->get()->result();
     foreach ($terms as $term)
-    	$sample_methods[] = $term->id.":".$term->term;
+    	$sample_methods[] = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
+    						":".
+    						str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
     
     $location_types = array(":No filter");
     $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:location_types')->orderby('term', 'asc')->get()->result();
     foreach ($terms as $term)
-    	$location_types[] = $term->id.':'.$term->term;
+    	$location_types[] = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
+    						":".
+    						str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
     
     return array(
       'website_id' => array( 

--- a/application/models/sample.php
+++ b/application/models/sample.php
@@ -270,23 +270,23 @@ class Sample_Model extends ORM_Tree
     $srefs = array();
     $systems = spatial_ref::system_list();
     foreach ($systems as $code=>$title) 
-    	$srefs[] = str_replace(array(',',':'), array('&#44', '&#56'), $code) .
-    				":".
-    				str_replace(array(',',':'), array('&#44', '&#56'), $title);
+      $srefs[] = str_replace(array(',',':'), array('&#44', '&#56'), $code) .
+          ":".
+          str_replace(array(',',':'), array('&#44', '&#56'), $title);
     
     $sample_methods = array(":Defined in file");
     $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:sample_methods')->orderby('term', 'asc')->get()->result();
     foreach ($terms as $term)
-    	$sample_methods[] = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
-    						":".
-    						str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
+      $sample_methods[] = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
+          ":".
+          str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
     
     $location_types = array(":No filter");
     $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:location_types')->orderby('term', 'asc')->get()->result();
     foreach ($terms as $term)
-    	$location_types[] = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
-    						":".
-    						str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
+      $location_types[] = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
+          ":".
+          str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
     
     return array(
       'website_id' => array( 

--- a/application/views/report/params.php
+++ b/application/views/report/params.php
@@ -62,7 +62,7 @@ foreach ($request['parameterRequest'] as $name => $det)
       $values = $det['lookup_values'];
 
       foreach ($values as $row=>$data) {
-		echo '<option value="'.str_replace(array('&#44', '&#56'), array(',',':'), $data->id).'">'.$data->caption.'</option>"';
+        echo '<option value="'.str_replace(array('&#44', '&#56'), array(',',':'), $data->id).'">'.$data->caption.'</option>"';
       }
       echo "</select>";
       break;

--- a/application/views/report/params.php
+++ b/application/views/report/params.php
@@ -62,7 +62,7 @@ foreach ($request['parameterRequest'] as $name => $det)
       $values = $det['lookup_values'];
 
       foreach ($values as $row=>$data) {
-        echo '<option value="'.$data->id.'">'.$data->caption.'</option>"';
+		echo '<option value="'.str_replace(array('&#44', '&#56'), array(',',':'), $data->id).'">'.$data->caption.'</option>"';
       }
       echo "</select>";
       break;

--- a/modules/indicia_svc_import/controllers/services/import.php
+++ b/modules/indicia_svc_import/controllers/services/import.php
@@ -61,10 +61,18 @@ class Import_Controller extends Service_Base_Controller {
    */
   public function get_import_fields($model) {
     $this->authenticate('read');
+    switch($model){
+    	case 'sample': $attrTypeFilter = empty($_GET['sample_method_id']) ? null : $_GET['sample_method_id'];
+    		break;
+    	case 'location': $attrTypeFilter = empty($_GET['location_type_id']) ? null : $_GET['location_type_id'];
+    		break;
+    	default: $attrTypeFilter = null;
+    		break;
+    }
     $model = ORM::factory($model);
     $website_id = empty($_GET['website_id']) ? null : $_GET['website_id'];
     $survey_id = empty($_GET['survey_id']) ? null : $_GET['survey_id'];
-    echo json_encode($model->getSubmittableFields(true, $website_id, $survey_id));
+    echo json_encode($model->getSubmittableFields(true, $website_id, $survey_id, $attrTypeFilter));
   }
   
   /**


### PR DESCRIPTION
Change to allow fetching of sample_method or location_type specific attributes when using upload into warehouse.
Also fixes an issue when using an sref or location_typ/sample_method with a comma or colon in it: these special characters are used by explode elsewhere in the code.

Must be accompanied by the equivalent pull into master for the client_helpers submodule, and that included in the deployment.