### PR TITLE
New filterable taxon report

### DIFF
--- a/reports/library/taxa/filterable_explore_list_multi_checklist.xml
+++ b/reports/library/taxa/filterable_explore_list_multi_checklist.xml
@@ -1,0 +1,33 @@
+<report
+    title="Explore distinct species using standard filters, multi checklist support."
+    description="Report designed for the explore records facility in iRecord, with standardised filtering parameters. Uses the external key to map across multiple checklists back to a single master list."
+>
+  <query website_filter_field="o.website_id" samples_id_field="o.sample_id" standard_params="true">
+  SELECT #columns#
+  FROM cache_occurrences o
+  JOIN cache_taxa_taxon_lists cttl on cttl.external_key=o.taxa_taxon_list_external_key and cttl.taxon_list_id=#master_taxon_list_id# and cttl.preferred=true
+  JOIN websites w on w.id=o.website_id and w.deleted=false
+  #agreements_join#
+  #joins#
+  WHERE #sharing_filter# 
+  AND o.zero_abundance=false
+  #idlist#
+  </query>
+  <order_bys>
+    <order_by>cttl.taxon_group, cttl.taxon ASC</order_by>
+  </order_bys>
+  <params>
+    <param name='master_taxon_list_id' display='Master taxon list' description='ID of the list to map all species back to when obtaining the preferred species details' datatype='integer' />
+  </params>
+  <columns>
+    <column name='taxon_meaning_id' display='ID' sql='cttl.taxon_meaning_id' visible="false" in_count="true" />
+    <column name='taxon' display='Preferred name' sql="cttl.taxon" />
+    <column name='common' display='Common name' sql="cttl.default_common_name" />
+    <column name='taxon_group' display='Taxon group' sql='cttl.taxon_group' />
+    <column name='taxon_group_id' display='Taxon group ID' sql='cttl.taxon_group_id' visible="false" />
+    <column name='taxonomy' display="Taxonomy" sql="COALESCE(cttl.kingdom_taxon || ' :: ', '') || COALESCE(cttl.order_taxon, '-') || ' :: ' || COALESCE(cttl.family_taxon, '-')" />
+    <column name="first_date" display="First record date" sql="min(coalesce(o.date_start, o.date_end))" aggregate="true" />
+    <column name="last_date" display="Last record date" sql="max(coalesce(o.date_end, o.date_start))" aggregate="true" />
+    <column name="count" display="Records" sql="count(distinct o.id)" aggregate="true" />
+  </columns>
+</report>


### PR DESCRIPTION
Maps the taxa reported back to a single master checklist which means
species names are not duplicated if there are variations between several
checklists in how they write the names.