### PR TITLE
Fix handling of FK and parents in CSV uploads where model has

### DIFF
--- a/application/libraries/MY_ORM.php
+++ b/application/libraries/MY_ORM.php
@@ -1742,8 +1742,10 @@ class ORM extends ORM_Core {
    * @return array The submission structure containing the fkFields element.
    */
   public function getFkFields($submission, $saveArray) {
-    // Can't use 'this' to access the FK or parent, as that doesn't work for the supermodels of 'this'
-    $submissionModel = ORM::Factory($submission['id']);
+  	if($this->object_name != $submission['id'])
+    	$submissionModel = ORM::Factory($submission['id'], -1);
+    else $submissionModel = $this;
+    
   	foreach ($submission['fields'] as $field=>$value) {
       if (substr($field, 0, 3)=='fk_') {
         // This field is a fk_* field which contains the text caption of a record which we need to lookup.

--- a/application/models/occurrence.php
+++ b/application/models/occurrence.php
@@ -457,6 +457,25 @@ class Occurrence_Model extends ORM
     	$srefs[] = str_replace(array(',',':'), array('&#44', '&#56'), $code) .
     				":".
     				str_replace(array(',',':'), array('&#44', '&#56'), $title);
+
+    $sample_methods = array(":Defined in file");
+    $parent_sample_methods = array();
+    $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:sample_methods')->orderby('term', 'asc')->get()->result();
+    foreach ($terms as $term) {
+    	$sample_method = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
+    	":".
+    	str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
+    	$sample_methods[] = $sample_method;
+    	$parent_sample_methods[] = $sample_method;
+    }
+    
+    $location_types = array(":No filter");
+    $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:location_types')->orderby('term', 'asc')->get()->result();
+    foreach ($terms as $term)
+    	$location_types[] = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
+    	":".
+    	str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
+    
     $retVal = array(
       'website_id' => array( 
         'display'=>'Website', 
@@ -479,6 +498,27 @@ class Occurrence_Model extends ORM
             'column in the import file which is mapped to the Sample Spatial Reference System field containing the spatial reference system code.', 
         'datatype'=>'lookup',
         'lookup_values'=>implode(',', $srefs)
+      ),
+      'sample:sample_method_id' => array(
+        'display'=>'Sample Method',
+        'description'=>'Select the sample method used for records in this import file. Note, if you have a file with a mix of sample methods then you need a '.
+            'column in the import file which is mapped to the Sample Sample Method field, containing the sample method.',
+        'datatype'=>'lookup',
+        'lookup_values'=>implode(',', $sample_methods)
+      ),
+      'fkFilter:sample:sample_method_id' => array(
+        'display'=>'Parent Sample Method',
+        'description'=>'If this import file includes samples which reference parent sample records, you can restrict the type of samples looked '.
+            'up by setting this sample method type. It is not currently possible to use a column in the file to do this on a sample by sample basis.',
+        'datatype'=>'lookup',
+        'lookup_values'=>implode(',', $parent_sample_methods)
+      ),
+      'fkFilter:location:location_type_id' => array(
+        'display'=>'Location Type',
+        'description'=>'If this import file includes samples which reference locations records, you can restrict the type of locations looked '.
+            'up by setting this location type. It is not currently possible to use a column in the file to do this on a sample by sample basis.',
+        'datatype'=>'lookup',
+        'lookup_values'=>implode(',', $location_types)
       ),
       // Also allow a field to be defined which defines the taxon list to look in when searching for species during a csv upload
       'occurrence:fkFilter:taxa_taxon_list:taxon_list_id'=>array(

--- a/application/models/occurrence.php
+++ b/application/models/occurrence.php
@@ -459,7 +459,7 @@ class Occurrence_Model extends ORM
     				str_replace(array(',',':'), array('&#44', '&#56'), $title);
 
     $sample_methods = array(":Defined in file");
-    $parent_sample_methods = array();
+    $parent_sample_methods = array(":No filter");
     $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:sample_methods')->orderby('term', 'asc')->get()->result();
     foreach ($terms as $term) {
     	$sample_method = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
@@ -499,27 +499,6 @@ class Occurrence_Model extends ORM
         'datatype'=>'lookup',
         'lookup_values'=>implode(',', $srefs)
       ),
-      'sample:sample_method_id' => array(
-        'display'=>'Sample Method',
-        'description'=>'Select the sample method used for records in this import file. Note, if you have a file with a mix of sample methods then you need a '.
-            'column in the import file which is mapped to the Sample Sample Method field, containing the sample method.',
-        'datatype'=>'lookup',
-        'lookup_values'=>implode(',', $sample_methods)
-      ),
-      'fkFilter:sample:sample_method_id' => array(
-        'display'=>'Parent Sample Method',
-        'description'=>'If this import file includes samples which reference parent sample records, you can restrict the type of samples looked '.
-            'up by setting this sample method type. It is not currently possible to use a column in the file to do this on a sample by sample basis.',
-        'datatype'=>'lookup',
-        'lookup_values'=>implode(',', $parent_sample_methods)
-      ),
-      'fkFilter:location:location_type_id' => array(
-        'display'=>'Location Type',
-        'description'=>'If this import file includes samples which reference locations records, you can restrict the type of locations looked '.
-            'up by setting this location type. It is not currently possible to use a column in the file to do this on a sample by sample basis.',
-        'datatype'=>'lookup',
-        'lookup_values'=>implode(',', $location_types)
-      ),
       // Also allow a field to be defined which defines the taxon list to look in when searching for species during a csv upload
       'occurrence:fkFilter:taxa_taxon_list:taxon_list_id'=>array(
         'display' => 'Species list',
@@ -538,6 +517,31 @@ class Occurrence_Model extends ORM
         'default' => 'C'
       )
     );
+    if(!empty($options['activate_global_sample_method']) && $options['activate_global_sample_method']==='t')
+    	$retVal['sample:sample_method_id'] = array(
+    			'display'=>'Sample Method',
+    			'description'=>'Select the sample method used for records in this import file. Note, if you have a file with a mix of sample methods then you need a '.
+    			'column in the import file which is mapped to the Sample Sample Method field, containing the sample method.',
+    			'datatype'=>'lookup',
+    			'lookup_values'=>implode(',', $sample_methods)
+    	);
+    if(!empty($options['activate_parent_sample_method_filter']) && $options['activate_parent_sample_method_filter']==='t')
+    	$retVal['fkFilter:sample:sample_method_id'] = array(
+    			'display'=>'Parent Sample Method',
+    			'description'=>'If this import file includes samples which reference parent sample records, you can restrict the type of samples looked '.
+    			'up by setting this sample method type. It is not currently possible to use a column in the file to do this on a sample by sample basis.',
+    			'datatype'=>'lookup',
+    			'lookup_values'=>implode(',', $parent_sample_methods)
+    	);
+    if(!empty($options['activate_location_location_type_filter']) && $options['activate_location_location_type_filter']==='t')
+    	$retVal['fkFilter:location:location_type_id'] = array(
+    			'display'=>'Location Type',
+    			'description'=>'If this import file includes samples which reference locations records, you can restrict the type of locations looked '.
+    			'up by setting this location type. It is not currently possible to use a column in the file to do this on a sample by sample basis.',
+    			'datatype'=>'lookup',
+    			'lookup_values'=>implode(',', $location_types)
+    	);
+    	 
     if(!empty($options['occurrence_associations']) && $options['occurrence_associations']==='t' &&
         self::_check_module_active('occurrence_associations')) {
       $retVal['useAssociations'] = array(

--- a/application/models/sample.php
+++ b/application/models/sample.php
@@ -268,7 +268,7 @@ class Sample_Model extends ORM_Tree
   /**
    * Define a form that is used to capture a set of predetermined values that apply to every record during an import.
    */
-  public function fixed_values_form() {
+  public function fixed_values_form($options=array()) {
     $srefs = array();
     $systems = spatial_ref::system_list();
     foreach ($systems as $code=>$title) 
@@ -277,7 +277,7 @@ class Sample_Model extends ORM_Tree
     				str_replace(array(',',':'), array('&#44', '&#56'), $title);
     
     $sample_methods = array(":Defined in file");
-    $parent_sample_methods = array();
+    $parent_sample_methods = array(":No filter");
     $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:sample_methods')->orderby('term', 'asc')->get()->result();
     foreach ($terms as $term) {
     	$sample_method = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
@@ -294,7 +294,7 @@ class Sample_Model extends ORM_Tree
     						":".
     						str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
     
-    return array(
+    $retval = array(
       'website_id' => array( 
         'display'=>'Website', 
         'description'=>'Select the website to import records into.', 
@@ -323,13 +323,6 @@ class Sample_Model extends ORM_Tree
         'datatype'=>'lookup',
         'lookup_values'=>implode(',', $sample_methods)
       ),
-      'fkFilter:sample:sample_method_id' => array(
-        'display'=>'Parent Sample Method', 
-        'description'=>'If this import file includes samples which reference parent sample records, you can restrict the type of samples looked '.
-      		'up by setting this sample method type. It is not currently possible to use a column in the file to do this on a sample by sample basis.',
-        'datatype'=>'lookup',
-      	'lookup_values'=>implode(',', $parent_sample_methods)
-      ),
       'fkFilter:location:location_type_id' => array(
         'display'=>'Location Type', 
         'description'=>'If this import file includes samples which reference locations records, you can restrict the type of locations looked '.
@@ -338,6 +331,16 @@ class Sample_Model extends ORM_Tree
         'lookup_values'=>implode(',', $location_types)
       )
     );
+    if(!empty($options['activate_parent_sample_method_filter']) && $options['activate_parent_sample_method_filter']==='t')
+    	$retval['fkFilter:sample:sample_method_id'] = array(
+    			'display'=>'Parent Sample Method',
+    			'description'=>'If this import file includes samples which reference parent sample records, you can restrict the type of samples looked '.
+    			'up by setting this sample method type. It is not currently possible to use a column in the file to do this on a sample by sample basis.',
+    			'datatype'=>'lookup',
+    			'lookup_values'=>implode(',', $parent_sample_methods)
+    	);
+    	 
+    return $retval;
   }
   
   /**

--- a/application/models/sample.php
+++ b/application/models/sample.php
@@ -57,6 +57,8 @@ class Sample_Model extends ORM_Tree
     'website_id' => 'Website ID',
   	// extra lookup options
   	'sample:fk_location:code' => 'Location Code',
+  	'sample:fk_location:external_key' => 'Location external key',
+  	'sample:fk_parent:external_key' => 'Parent sample external key',
   	'sample:date:day' => 'Day (Builds date)',
   	'sample:date:month' => 'Month (Builds date)',
   	'sample:date:year' => 'Year (Builds date)'
@@ -275,11 +277,15 @@ class Sample_Model extends ORM_Tree
     				str_replace(array(',',':'), array('&#44', '&#56'), $title);
     
     $sample_methods = array(":Defined in file");
+    $parent_sample_methods = array();
     $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:sample_methods')->orderby('term', 'asc')->get()->result();
-    foreach ($terms as $term)
-    	$sample_methods[] = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
+    foreach ($terms as $term) {
+    	$sample_method = str_replace(array(',',':'), array('&#44', '&#56'), $term->id) .
     						":".
     						str_replace(array(',',':'), array('&#44', '&#56'), $term->term);
+    	$sample_methods[] = $sample_method;
+    	$parent_sample_methods[] = $sample_method;
+    }
     
     $location_types = array(":No filter");
     $terms = $this->db->select('id, term')->from('list_termlists_terms')->where('termlist_external_key', 'indicia:location_types')->orderby('term', 'asc')->get()->result();
@@ -316,6 +322,13 @@ class Sample_Model extends ORM_Tree
             'column in the import file which is mapped to the Sample Sample Method field, containing the sample method.', 
         'datatype'=>'lookup',
         'lookup_values'=>implode(',', $sample_methods)
+      ),
+      'fkFilter:sample:sample_method_id' => array(
+        'display'=>'Parent Sample Method', 
+        'description'=>'If this import file includes samples which reference parent sample records, you can restrict the type of samples looked '.
+      		'up by setting this sample method type. It is not currently possible to use a column in the file to do this on a sample by sample basis.',
+        'datatype'=>'lookup',
+      	'lookup_values'=>implode(',', $parent_sample_methods)
       ),
       'fkFilter:location:location_type_id' => array(
         'display'=>'Location Type', 

--- a/application/views/importer.php
+++ b/application/views/importer.php
@@ -30,7 +30,11 @@ $auth = import_helper::get_read_write_auth(0-$_SESSION['auth_user']->id, kohana:
 
 echo import_helper::importer(array(
   'model' => $this->controllerpath,
-  'auth' => $auth  
+  'auth' => $auth,
+  'switches' => array('activate_parent_sample_method_filter' => 't',
+  						'activate_global_sample_method' => 't',
+  						'activate_location_location_type_filter' => 't',
+  						'occurrence_associations' => 't')  
 ));
 import_helper::$dumped_resources[] = 'jquery';
 import_helper::$dumped_resources[] = 'jquery-ui';

--- a/modules/indicia_svc_import/controllers/services/import.php
+++ b/modules/indicia_svc_import/controllers/services/import.php
@@ -404,12 +404,15 @@ class Import_Controller extends Service_Base_Controller {
               	array('record1' => array('fkId' => $superModelFK, 'model' => $submissionData),
                        'record2'=> array('fkId' => $superModelFK, 'model' => $associatedSubmission));
             $superModel->submission = $superModelSubmission;
-            $model = $superModel;
-        } else $associationExists = false;
-        if (($id = $model->submit()) == null) {
+            $modelToSubmit = $superModel;
+        } else {
+          $associationExists = false;
+          $modelToSubmit = $model;
+        }
+        if (($id = $modelToSubmit->submit()) == null) {
           // Record has errors - now embedded in model, so dump them into the error file
           $errors = array();
-          foreach($model->getAllErrors() as $field=>$msg) {
+          foreach($modelToSubmit->getAllErrors() as $field=>$msg) {
             $fldTitle = array_search($field, $metadata['mappings']);
             $fldTitle = $fldTitle ? $fldTitle : $field;
             $errors[] = "$fldTitle: $msg";
@@ -424,7 +427,7 @@ class Import_Controller extends Service_Base_Controller {
           // now the record has successfully posted, we need to store the details of any new supermodels and their Ids, 
           // in case they are duplicated in the next csv row.
           $this->previousCsvSupermodel['details'] = array_merge($this->previousCsvSupermodel['details'], $updatedPreviousCsvSupermodelDetails);
-          $this->captureSupermodelIds($model, $associationExists);
+          $this->captureSupermodelIds($modelToSubmit, $associationExists);
         }
         // get file position here otherwise the fgetcsv in the while loop will move it one record too far. 
         $filepos = ftell($handle);


### PR DESCRIPTION
supermodels (e.g. occurrences has samples). Fix exception when FK lookup
by ID fails. Add sample_method to occurrence fixed_value_form along with
FK filters for location location_type and parent sample sample_method.
Add fk parent sample and location lookups by external key for sample CSV
upload, and in fixed_value_form add FK filter for parent sample
sample_method.