### PR TITLE
UKBMS Species/Occurrence Report: fix filtering.

### DIFF
--- a/reports/reports_for_prebuilt_forms/UKBMS/ukbms_species_and_occurrence_counts_with_code.xml
+++ b/reports/reports_for_prebuilt_forms/UKBMS/ukbms_species_and_occurrence_counts_with_code.xml
@@ -17,6 +17,7 @@
       ) AS lsub
       JOIN locations l on l.id=lsub.id
       #joins#
+      WHERE 1=1
       </query>
       <order_bys>
             <order_by>occurrences DESC</order_by>


### PR DESCRIPTION
Without a WHERE clause in the report the filters become part of the
JOINs, not the main query. When the JOINs include an (optional) LEFT
JOIN attribute, this means the filter is not applied to the main query.