### PR TITLE
Make My Walks and Branch Walks reports consistent.

### DIFF
--- a/reports/reports_for_prebuilt_forms/UKBMS/ukbms_branch_walks_list.xml
+++ b/reports/reports_for_prebuilt_forms/UKBMS/ukbms_branch_walks_list.xml
@@ -9,7 +9,8 @@
       LEFT JOIN cache_termlists_terms ctt on ctt.id=s.sample_method_id
       LEFT JOIN locations l ON l.id=s.location_id
       #joins#
-    WHERE s.deleted = FALSE AND s.parent_id IS NULL
+    WHERE s.deleted = FALSE
+      AND s.parent_id IS NULL
       AND #website_filter#
       AND (CAST(s.survey_id AS character varying)='#survey_id#' OR '#survey_id#'='')
       AND (CAST(s.sample_method_id AS character varying)='#sample_method_id#' OR '#sample_method_id#'='' OR ctt.term='#sample_method_id#')
@@ -19,10 +20,6 @@
       #filters#
     #order_by#
   </query>
-  <order_bys>
-    <order_by>s.id DESC</order_by>
-    <order_by>s.date_start DESC</order_by>
-  </order_bys>
   <field_sql>
     s.id as sample_id,
     su.title as survey,
@@ -34,19 +31,19 @@
     s.date_end,
     s.date_type
   </field_sql>
+  <order_bys>
+    <order_by>s.id DESC</order_by>
+    <order_by>s.date_start DESC</order_by>
+  </order_bys>
   <params>
+    <param name='survey_id' display='Survey' description='Select the survey, or leave for all surveys' datatype='lookup'
+        population_call='direct:survey:id:title' />
     <param name='date_from' display='Date From' datatype='date' />
     <param name='date_to' display='Date To' datatype='date' />
-    <param name='survey_id' display='Survey' description='Select the survey to return data for, or leave for all surveys' datatype='lookup'
-            query='SELECT id, title as caption FROM surveys' population_call='direct:survey:id:title' />
     <param name='location_id' display='Location ID' description='Enter the Location ID.' datatype='int' />
     <param name='locattrs' display='Location attribute list' description='Comma separated list of location attribute IDs to include' datatype='locattrs' />
     <param name='sample_method_id' display='Sample Method' description='Select the sample method, or leave blank to not filter by sample method.' datatype='lookup'
             population_call='report:library/terms/terms_list:termlists_term_id:term:termlist_external_key=indicia:sample_methods,termlist_id=' />
-    <param name='location_type_id' display='Location Type ID' description='Enter the type of location' datatype='lookup'
-            population_call='report:library/terms/terms_list:termlists_term_id:term:termlist_external_key=indicia:location_types,termlist_id=' >
-      <where>l.location_type_id=#location_type_id#</where>
-    </param>
   </params>
   <columns>
     <column name='sample_id' visible='true' />

--- a/reports/reports_for_prebuilt_forms/UKBMS/ukbms_my_walks_list.xml
+++ b/reports/reports_for_prebuilt_forms/UKBMS/ukbms_my_walks_list.xml
@@ -1,25 +1,23 @@
 <report
-    title="UKBMS Walks: Top level samples list for a CMS user"
+    title="UKBMS Walks: Top level samples list for an Indicia user"
     description="A list of top level samples for use in the UKBMS My Walks report calendar grid. Filtered according to the Indicia ID of the user, and optional location ID. Top level means that the parent_id field of the samples is null."
 >
 <query website_filter_field="su.website_id">
   SELECT #field_sql#
   FROM samples s
-  JOIN surveys su on su.id=s.survey_id and su.deleted=false
-  LEFT JOIN (termlists_terms ttl1
-    INNER JOIN termlists_terms ttl2 ON ttl2.meaning_id=ttl1.meaning_id
-    INNER JOIN terms t ON t.id=ttl2.term_id
-  ) ON ttl1.id=s.sample_method_id
-  LEFT JOIN locations l ON l.id=s.location_id
+    JOIN surveys su on su.id=s.survey_id and su.deleted=false
+    LEFT JOIN cache_termlists_terms ctt on ctt.id=s.sample_method_id
+    LEFT JOIN locations l ON l.id=s.location_id
   #joins#
   WHERE s.deleted = FALSE
   AND s.parent_id IS NULL
   AND #website_filter#
   AND (CAST(s.survey_id AS character varying)='#survey_id#' OR '#survey_id#'='')
-  AND (CAST(ttl2.id AS character varying)='#sample_method_id#' OR '#sample_method_id#'='' OR t.term='#sample_method_id#')
+  AND (CAST(s.sample_method_id AS character varying)='#sample_method_id#' OR '#sample_method_id#'='' OR ctt.term='#sample_method_id#')
   AND (trim('#date_from#')='' OR '#date_from#'='Click here' OR s.date_end &gt;= CAST(COALESCE('#date_from#','1500-01-01') as date))
       AND (trim('#date_to#')='' OR '#date_to#'='Click here' OR s.date_start &lt;= CAST(COALESCE('#date_to#','1500-01-01') as date))
   AND (CAST(l.id AS character varying)='#location_id#' OR '#location_id#' = '')
+  #filters#
   #order_by#
   </query>
   <field_sql>
@@ -46,7 +44,6 @@
       <where>s.created_by_id=#user_id#</where>
     </param>
     <param name='location_id' display='Location ID' description='Enter the Location ID.' datatype='int' />
-    <param name='smpattrs' display='Sample attribute list' description='Comma separated list of sample attribute IDs to include' datatype='smpattrs' />
     <param name='sample_method_id' display='Sample Method' description='Select the sample method, or leave blank to not filter by sample method.' datatype='lookup'
             population_call='report:library/terms/terms_list:termlists_term_id:term:termlist_external_key=indicia:sample_methods,termlist_id=' />
   </params>


### PR DESCRIPTION
Main change is removal of location_type_id param from branch report, see
UKBMS Issue 42: the selection of walks is driven by the survey_id, not
the location type. Also removes smpattrs from my walks as not used.