### PR TITLE
Don't send emails if do_not_send email config set

### DIFF
--- a/application/controllers/forgotten_password.php
+++ b/application/controllers/forgotten_password.php
@@ -27,6 +27,7 @@
 class Forgotten_Password_Controller extends Indicia_Controller {
 
   public function index() {
+
     if ($this->auth->logged_in()) {
       $this->template->title = 'Already Logged In';
       $this->template->content = new View('login/login_message');
@@ -69,7 +70,10 @@ class Forgotten_Password_Controller extends Indicia_Controller {
 
   public function send_from_user($id = NULL) {
     $email_config = Kohana::config('email');
-
+    if (array_key_exists ('do_not_send' , $email_config) and $email_config['do_not_send']) {
+      kohana::log('info', "Email configured for do_not_send: ignoring send_from_user");
+      return;
+    }
     $this->template->title = 'Forgotten Password Email Request';
     $this->template->content = new View('login/login_message');
     $this->template->content->message = 'You are already logged in.<br />';

--- a/application/controllers/scheduled_tasks.php
+++ b/application/controllers/scheduled_tasks.php
@@ -81,9 +81,14 @@ class Scheduled_Tasks_Controller extends Controller {
       $this->runScheduledPlugins($system, $scheduledPlugins);
     }
     if (in_array('notifications', $nonPluginTasks)) {
-      $swift = email::connect();
-      $this->doRecordOwnerNotifications($swift);
-      $this->doDigestNotifications($swift);
+      $email_config = Kohana::config('email');
+      if (array_key_exists ('do_not_send' , $email_config) and $email_config['do_not_send']){
+        kohana::log('info', "Email configured for do_not_send: ignoring notifications from scheduled tasks");
+      } else {
+        $swift = email::connect();
+        $this->doRecordOwnerNotifications($swift);
+        $this->doDigestNotifications($swift);
+      }
     }
     if (in_array('work_queue', $nonPluginTasks)) {
       $timeAtStart = microtime(TRUE);

--- a/modules/indicia_auth/libraries/Auth.php
+++ b/modules/indicia_auth/libraries/Auth.php
@@ -440,7 +440,10 @@ class Auth_Core {
     Kohana::log('debug', 'Entering Auth_Core->send_forgotten_password_mail');
 
     $email_config = Kohana::config('email');
-
+    if (array_key_exists ('do_not_send' , $email_config) and $email_config['do_not_send']){
+      kohana::log('info', "Email configured for do_not_send: ignoring send_forgotten_password_mail");
+      return;
+    }
     $link_code = $this->hash_password($user->username);
     $user->__set('forgotten_password_key', $link_code);
     $user->save();

--- a/modules/notification_emails/plugins/notification_emails.php
+++ b/modules/notification_emails/plugins/notification_emails.php
@@ -510,6 +510,12 @@ function send_out_user_email(
     $emailAddress,
     $subscriptionSettingsPageUrl,
     $highPriority) {
+
+  $email_config = Kohana::config('email');
+  if (array_key_exists ('do_not_send' , $email_config) and $email_config['do_not_send']){
+    kohana::log('info', "Email configured for do_not_send: ignoring send_out_user_email");
+    return;
+  }
   //AVB note: The warehouse_url param is now redundant and can be removed next time testing is carried out on this page.
   $emailContent .= '<br><a href="' . $subscriptionSettingsPageUrl . '?user_id=' . $userId . '&warehouse_url=' .
     url::base() . '">Click here to update your subscription settings.</a><br/><br/>';


### PR DESCRIPTION
Addresses Warehouse issue https://github.com/Indicia-Team/warehouse/issues/323.

Updated a number of Warehouse classes so that they do not attempt to send emails if a do_not_send config variable is set to true  in the application/config/email.php file. The code will work as at present if that variable is not set in the config file or if it is set to false. But if it is set to true, emails are not sent.

If email is not configured properly, code breaks at the point where it connects to the email service: `email::connect()`. I found that pattern in six PHPfiles and I updated four of them to check for the config setting and return silently (although logging an info message) if it is set without actually sending email. I have only actually tested on my localhost for situations were Indicia user requesting email for forgotten password. It could use more testing on irecord-dev.