### PR TITLE
Fix for system allowing vague dates were start after end date

### DIFF
--- a/application/helpers/vague_date.php
+++ b/application/helpers/vague_date.php
@@ -193,7 +193,7 @@ class vague_date {
         $end = new DateTime($date[1]);
       }
     }
-    self::validate($start, $end, $type);
+    //self::validate(array($start, $end, $type);
     switch ($type) {
       case 'D':
         return self::vague_date_to_day($start, $end);
@@ -347,7 +347,7 @@ class vague_date {
             $endDate->getImpreciseDateEnd(),
             'P'
           );
-          return $vagueDate;
+          return self::validate($vagueDate);
         } else {
           // No year, so we're an S
           $vagueDate = array(
@@ -355,7 +355,7 @@ class vague_date {
             $endDate->getImpreciseDateEnd(),
             'S'
           );
-          return $vagueDate;
+          return self::validate($vagueDate);
         }
       }
       // Do we have day precision?
@@ -368,7 +368,7 @@ class vague_date {
             $endDate->getIsoDate(),
             'D'
           );
-          return $vagueDate;
+          return self::validate($vagueDate);
         } else {
           // Type is DD. We copy across any data not set in the
           // start date.
@@ -383,7 +383,7 @@ class vague_date {
             // try and massage them together
             return false;
           }
-          return $vagueDate;
+          return self::validate($vagueDate);
 
         }
       }
@@ -405,7 +405,7 @@ class vague_date {
               $endDate->getImpreciseDateEnd(),
               'O'
             );
-            return $vagueDate;
+            return self::validate($vagueDate);
           } else {
             // Month without a year - type M
             $vagueDate = array(
@@ -413,7 +413,7 @@ class vague_date {
               $endDate->getImpreciseDateEnd(),
               'M'
             );
-            return $vagueDate;
+            return self::validate($vagueDate);
           }
         } else {
           // We do have a range, OO
@@ -424,7 +424,7 @@ class vague_date {
               $endDate->getImpreciseDateEnd(),
               'OO'
             );
-            return $vagueDate;
+            return self::validate($vagueDate);
           } else {
             // MM is not an allowed type
             // TODO think about this
@@ -447,7 +447,7 @@ class vague_date {
             $endDate->getImpreciseDateEnd(),
             'C'
           );
-          return $vagueDate;
+          return self::validate($vagueDate);
         } else {
           if ($start && $end) {
             // We're CC
@@ -456,7 +456,7 @@ class vague_date {
               $endDate->getImpreciseDateEnd(),
               'CC'
             );
-            return $vagueDate;
+            return self::validate($vagueDate);
           } else if ($start && !$end) {
             // We're C-
             $vagueDate = array(
@@ -464,7 +464,7 @@ class vague_date {
               null,
               'C-'
             );
-            return $vagueDate;
+            return self::validate($vagueDate);
           } else if ($end && !$start) {
             // We're -C
             $vagueDate = array(
@@ -472,7 +472,7 @@ class vague_date {
               $endDate->getImpreciseDateEnd(),
               '-C'
             );
-            return $vagueDate;
+            return self::validate($vagueDate);
           }
         }
       }
@@ -486,7 +486,7 @@ class vague_date {
             $endDate->getImpreciseDateEnd(),
             'Y'
           );
-          return $vagueDate;
+          return self::validate($vagueDate);
         } else {
           if ($start && $end){
             // We're YY
@@ -495,7 +495,7 @@ class vague_date {
               $endDate->getImpreciseDateEnd(),
               'YY'
             );
-            return $vagueDate;
+            return self::validate($vagueDate);
           } else if ($start && !$end){
             // We're Y-
             $vagueDate = array(
@@ -503,7 +503,7 @@ class vague_date {
               null,
               'Y-'
             );
-            return $vagueDate;
+            return self::validate($vagueDate);
           } else if ($end && !$start){
             // We're -Y
             $vagueDate = array(
@@ -511,7 +511,7 @@ class vague_date {
               $endDate->getImpreciseDateEnd(),
               '-Y'
             );
-            return $vagueDate;
+            return self::validate($vagueDate);
           }
         }
       } else {
@@ -831,9 +831,18 @@ class vague_date {
   /**
    * Ensure a vague date array is well-formed.
    */
-  protected static function validate($start, $end, $type)
+  protected static function validate($vagueDate)
   {
+    $start = $vagueDate[0];
+    $end = $vagueDate[1];
+    $type = $vagueDate[2];
 
+    if ($start > $end) {
+      //End date must be after start date
+      return false;
+    } else {
+      return $vagueDate;
+    }
   }
 
   /**

--- a/application/helpers/vague_date.php
+++ b/application/helpers/vague_date.php
@@ -837,7 +837,7 @@ class vague_date {
     $end = $vagueDate[1];
     $type = $vagueDate[2];
 
-    if ($start > $end) {
+    if ($end < $start && !is_null($end)) {
       //End date must be after start date
       return false;
     } else {

--- a/application/tests/helpers/vague_dateTest.php
+++ b/application/tests/helpers/vague_dateTest.php
@@ -1,4 +1,5 @@
 <?php
+
 class Helper_Vague_Date_Test extends PHPUnit_Framework_TestCase {
 
   /*****************************
@@ -294,6 +295,8 @@ class Helper_Vague_Date_Test extends PHPUnit_Framework_TestCase {
         'Date 34 march 73' => ['34 march 73'],
         'Date 100/13/2001' => ['100/13/2001'],
         'Date 06/1992-1996' => ['06/1992-1996'],
+        'Date Dec 2017 to Apr 2019' => ['Dec 2017 to Apr 2019'],
+        'Date Apr 2019 to Dec 2017' => ['Apr 2019 to Dec 2017'],
     ];
   }
 

--- a/application/tests/helpers/vague_dateTest.php
+++ b/application/tests/helpers/vague_dateTest.php
@@ -295,8 +295,8 @@ class Helper_Vague_Date_Test extends PHPUnit_Framework_TestCase {
         'Date 34 march 73' => ['34 march 73'],
         'Date 100/13/2001' => ['100/13/2001'],
         'Date 06/1992-1996' => ['06/1992-1996'],
-        'Date Dec 2017 to Apr 2019' => ['Dec 2017 to Apr 2019'],
         'Date Apr 2019 to Dec 2017' => ['Apr 2019 to Dec 2017'],
+        'Date 04/2019 to 12/2017' => ['04/2019 to 12/2017'],
     ];
   }
 


### PR DESCRIPTION
Updated string_to_vague_date function so that it returns vague_date via call to a function called validate which returns false if invalid and returns the vague_date if okay. Currently function only checks to ensure that end date is after start date.

This validate function actually already existed in the code but did nothing (empty body). However it was called from the vague_date_to_string function. I commented this call out. It seems that function relies on format-specific functions it calls to validate stuff.

Added a couple of tests to the units tests to test for end date before start date.