### PR TITLE
UKBMS Issue 119

### DIFF
--- a/modules/summary_builder/helpers/task_summary_builder_sample.php
+++ b/modules/summary_builder/helpers/task_summary_builder_sample.php
@@ -42,7 +42,8 @@ class task_summary_builder_sample {
   public static function process($db, $taskType, $procId) {
     $queries = kohana::config('summary_builder');
     // This query gets all the samples to be processed that are on a survey which does summarisation
-    $query = str_replace('#procId#', $procId, $queries['get_samples_to_process']);
+    $query = str_replace(['#procId#', '#task#'], [$procId, 'task_summary_builder_sample'],
+        $queries['get_samples_to_process']);
     $result = $db->query($query)->result_array(false);
     foreach($result as $row){
        summary_builder::populate_summary_table_for_sample($db, $row['sample_id'], $row['definition_id']);


### PR DESCRIPTION
The logic prevent the extra calculations is too restrictive, and seems
to cause issues when processing several samples on the same location at
the same time.
This extra check has been removed: it may mean that in a few cases the
summary calculations will be repeated, but from a performance viewpoint
there should also be a speedup as the queries are simplified for every
sample and occurrence.