### PR TITLE
Added Warehouse features for Survey auto-verify filtering

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -29,14 +29,14 @@ defined('SYSPATH') or die('No direct script access.');
  *
  * @var string
  */
-$config['version'] = '2.35.2';
+$config['version'] = '2.36.0';
 
 /**
  * Version release date.
  *
  * @var string
  */
-$config['release_date'] = '2019-10-12';
+$config['release_date'] = '2019-10-14';
 
 /**
  * Link to the code repository downloads page.

--- a/application/models/survey.php
+++ b/application/models/survey.php
@@ -54,9 +54,25 @@ class Survey_Model extends ORM_Tree {
       'owner_id',
       'auto_accept',
       'auto_accept_max_difficulty',
+      'auto_accept_taxa_filters',
       'core_validation_rules',
     );
     return parent::validate($array, $save);
   }
 
+  protected function preSubmit() {
+    if (!empty($_POST['has-taxon-restriction-data'])) {
+      $ttlIds = [];
+      foreach ($_POST as $key => $value) {
+        if (substr($key, -8) === ':present' && $value !== '0') {
+          $taxonMeaningId = $this->db
+              ->query('SELECT taxon_meaning_id FROM cache_taxa_taxon_lists WHERE id=' . $value)
+              ->current();
+          $ttlIds[] = intVal($taxonMeaningId->taxon_meaning_id);
+        }  
+      }
+      $this->submission['fields']['auto_accept_taxa_filters']=array('value' => $ttlIds);
+    }
+    return parent::presubmit();
+  }
 }

--- a/application/models/survey.php
+++ b/application/models/survey.php
@@ -63,15 +63,22 @@ class Survey_Model extends ORM_Tree {
   protected function preSubmit() {
     if (!empty($_POST['has-taxon-restriction-data'])) {
       $ttlIds = [];
+      $tmIds = [];
       foreach ($_POST as $key => $value) {
         if (substr($key, -8) === ':present' && $value !== '0') {
-          $taxonMeaningId = $this->db
-              ->query('SELECT taxon_meaning_id FROM cache_taxa_taxon_lists WHERE id=' . $value)
-              ->current();
-          $ttlIds[] = intVal($taxonMeaningId->taxon_meaning_id);
+          $ttlIds[] = $value;
         }  
       }
-      $this->submission['fields']['auto_accept_taxa_filters']=array('value' => $ttlIds);
+      $tmIdRecs = $this->db
+          ->select('id, taxon_meaning_id')
+          ->from('cache_taxa_taxon_lists')
+          ->in('id', $ttlIds)
+          ->get()->result();
+
+      foreach ($tmIdRecs as $tmIdRec) {
+        $tmIds[] = intVal($tmIdRec->taxon_meaning_id);
+      }
+      $this->submission['fields']['auto_accept_taxa_filters']=array('value' => $tmIds);
     }
     return parent::presubmit();
   }

--- a/application/views/survey/survey_edit.php
+++ b/application/views/survey/survey_edit.php
@@ -138,6 +138,36 @@ $readAuth = data_entry_helper::get_read_auth(0 - $_SESSION['auth_user']->id, koh
         'helpText' => 'If Auto Accept is set, then this is the minimum identification difficulty that will be auto verified.',
       ));
     }
+    if (array_key_exists('survey:auto_accept_taxa_filters', $values)) {
+      $masterListId = warehouse::getMasterTaxonListId();
+      echo <<<HTML
+<div class="alert alert-info">
+ <p>You can use the taxon selection control below to 
+ select one or more higher level taxa to which recorded taxa must belong in order to
+ quality for auto-verification. Leave the list empty for no filtering. You must also
+ check the Auto Accept box for these filters to take effect.</p>
+</div>
+<label>Taxon restrictions</label>
+<input type="hidden" name="has-taxon-restriction-data" value="1" />
+HTML;
+      require_once 'client_helpers/prebuilt_forms/includes/language_utils.php';
+      $speciesChecklistOptions = [
+        'lookupListId' => $masterListId,
+        'rowInclusionCheck' => 'alwaysRemovable',
+        'extraParams' => $readAuth,
+        'survey_id' => $values['survey:id'],
+        'language' => iform_lang_iso_639_2(kohana::config('indicia.default_lang')),
+      ];
+      if (!empty($other_data['taxon_restrictions'])) {
+        $speciesChecklistOptions['listId'] = $masterListId;
+        $speciesChecklistOptions['preloadTaxa'] = [];
+        foreach ($other_data['taxon_restrictions'] as $restriction) {
+          $speciesChecklistOptions['preloadTaxa'][] = $restriction['taxa_taxon_list_id'];
+        }
+      }
+      echo data_entry_helper::species_checklist($speciesChecklistOptions);
+      echo '<br/>';
+    }
     ?>
   </fieldset>
   <?php if (array_key_exists('attributes', $values) && count($values['attributes']) > 0) : ?>

--- a/modules/auto_verify/db/version_2_36_0/201910071330_new_survey_fields.sql
+++ b/modules/auto_verify/db/version_2_36_0/201910071330_new_survey_fields.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE function f_add_new_survey_fields (OUT success bool)
+    LANGUAGE plpgsql AS
+$func$
+BEGIN 
+  
+success := TRUE;
+
+BEGIN
+	ALTER TABLE surveys ADD COLUMN auto_accept_taxa_filters INT[];
+
+EXCEPTION
+    WHEN duplicate_column THEN 
+      RAISE NOTICE 'column exists.';
+      success := FALSE;
+END;
+
+END
+$func$;
+
+SELECT f_add_new_survey_fields();
+
+DROP FUNCTION f_add_new_survey_fields();
+
+COMMENT ON COLUMN surveys.auto_accept_taxa_filters IS 'List of taxon meaning IDs to filter records qualifying for auto-verification';


### PR DESCRIPTION
@johnvanbreda - this is not for merging. It's just so you can review the code and I can ask you a question about it.

This includes everything necessary to be able to specify taxa against surveys that will be used as filters for auto-verification. I haven't touched the auto-verification yet.

It all works and looks like the image below. But I think that there might be a better way to populate `$otherData['taxon_restrictions']` from the DB - I'll add a comment/question on the relevant code below.

![image](https://user-images.githubusercontent.com/9275178/66941084-1f94e100-f03e-11e9-863b-f5285228c09d.png)

