### PR TITLE
Update auto_verify to take account of taxon restrictions

### DIFF
--- a/modules/auto_verify/plugins/auto_verify.php
+++ b/modules/auto_verify/plugins/auto_verify.php
@@ -23,8 +23,13 @@
 /**
  * Hook into the task scheduler. When run, the system checks the
  * cache_occurrences_functional table for records where the data cleaner has
- * marked the record as data_cleaner_info "pass", record_status="C", the system
- * then sets the record to verified automatically.
+ * marked the record as data_cleaner_result to true, record_status="C", the system
+ * then sets the record to verified automatically (subject to taxon restriction
+ * tests descrbed below).
+ * If the survey associated with the record has a value in its 
+ * auto_accept_taxa_filters field, then the taxon_meaning_id associated with 
+ * the record has to be the same as, or a decendent of, one of the
+ * taxa stored in the auto_accept_taxa_filters to qualify for auto verification.
  *
  * @param string $last_run_date
  *   Date last run, or null if never run.
@@ -73,7 +78,10 @@ function auto_verify_scheduled_task($last_run_date, $db) {
     AND delta.record_status='C' AND delta.record_substatus IS NULL
         AND delta.created_on >= TO_TIMESTAMP('$oldestRecordCreatedDateToProcess', 'DD/MM/YYYY')
         AND (($autoVerifyNullIdDiff=false AND cts.identification_difficulty IS NOT NULL AND cts.identification_difficulty<=s.auto_accept_max_difficulty)
-        OR ($autoVerifyNullIdDiff=true AND (cts.identification_difficulty IS NULL OR cts.identification_difficulty<=s.auto_accept_max_difficulty)))";
+        OR ($autoVerifyNullIdDiff=true AND (cts.identification_difficulty IS NULL OR cts.identification_difficulty<=s.auto_accept_max_difficulty)))
+    AND (s.auto_accept_taxa_filters is null
+      OR delta.taxon_meaning_id = ANY (s.auto_accept_taxa_filters)
+      OR (s.auto_accept_taxa_filters && delta.taxon_path))";
 
   if (isset($oldestOccurrenceIdToProcess) && $oldestOccurrenceIdToProcess > -1) {
     $subQuery .= "

--- a/modules/auto_verify/plugins/auto_verify.php
+++ b/modules/auto_verify/plugins/auto_verify.php
@@ -79,9 +79,7 @@ function auto_verify_scheduled_task($last_run_date, $db) {
         AND delta.created_on >= TO_TIMESTAMP('$oldestRecordCreatedDateToProcess', 'DD/MM/YYYY')
         AND (($autoVerifyNullIdDiff=false AND cts.identification_difficulty IS NOT NULL AND cts.identification_difficulty<=s.auto_accept_max_difficulty)
         OR ($autoVerifyNullIdDiff=true AND (cts.identification_difficulty IS NULL OR cts.identification_difficulty<=s.auto_accept_max_difficulty)))
-    AND (s.auto_accept_taxa_filters is null
-      OR delta.taxon_meaning_id = ANY (s.auto_accept_taxa_filters)
-      OR (s.auto_accept_taxa_filters && delta.taxon_path))";
+    AND (s.auto_accept_taxa_filters is null OR (s.auto_accept_taxa_filters && delta.taxon_path))";
 
   if (isset($oldestOccurrenceIdToProcess) && $oldestOccurrenceIdToProcess > -1) {
     $subQuery .= "


### PR DESCRIPTION
Addition to the auto-verify SQL to further restrict qualifying occurrences to those for taxa in, or descended from taxa in, a list stored against a survey. Addresses issue: https://github.com/BiologicalRecordsCentre/iRecord/issues/486

See also: https://github.com/Indicia-Team/warehouse/pull/335
