### PR TITLE
UKBMS Issue 122

### DIFF
--- a/modules/summary_builder/db/version_2_37_0/201910302245_work_queue.sql
+++ b/modules/summary_builder/db/version_2_37_0/201910302245_work_queue.sql
@@ -1,0 +1,14 @@
+-- #slow script#
+
+-- trigger a rebuild of any modified samples. Only bother with 2019 and later modifications, as a full rebuild
+-- was done during 2019 with the deployment of the new version of the summary builder.
+
+INSERT INTO work_queue (task, entity, record_id, priority, cost_estimate, created_on)
+SELECT DISTINCT 'task_summary_builder_sample', 'sample', id, 2, 50, now()
+FROM samples
+WHERE deleted=false
+AND parent_id IS NULL
+AND survey_id IN (SELECT survey_id FROM summariser_definitions WHERE deleted = false)
+AND created_on <> updated_on
+AND updated_on >= CAST('2019-01-01' as date)
+;

--- a/modules/summary_builder/plugins/summary_builder.php
+++ b/modules/summary_builder/plugins/summary_builder.php
@@ -29,14 +29,13 @@ function summary_builder_orm_work_queue() {
   return [
     [
       /* It is only the presence/absence of a sample that affects the values/estimates, so this is invoked on insert or
-       * deletion, not update.
+       * deletion, but it is also possible for the UKBMS front end to modify the date.
        * There is a possibility that if the date on a sample changes to a different year, the the old year values
        * will not be updated - similar if the location is moved. Operationally, this is a very remote possibility,
        * and will be covered by allowing the warehouse front end to trigger a rebuild of a locations data.
-       * In addition the UKBMS front end can not change the date or location.
        */
       'entity' => 'sample',
-      'ops' => ['insert', 'delete'],
+      'ops' => ['insert', 'delete', 'update'],
       'task' => 'task_summary_builder_sample',
       'cost_estimate' => 50,
       'priority' => 2,


### PR DESCRIPTION
Summary builder needs to handle changes of dates on samples.

When this is deployed, the work-queue-helpers warehouse cache needs to be cleared.