### PR TITLE
Feature : Import changes for UKBMS

### DIFF
--- a/application/models/location.php
+++ b/application/models/location.php
@@ -42,6 +42,7 @@ class Location_Model extends ORM_Tree {
   // Declare additional fields required when posting via CSV.
   protected $additional_csv_fields = array(
     // extra lookup options
+    'location:fk_parent:id' => 'Parent Indicia ID',
     'location:fk_parent:code' => 'Parent location Code',
     'location:fk_parent:external_key' => 'Parent location External key',
   );

--- a/application/models/occurrence.php
+++ b/application/models/occurrence.php
@@ -48,7 +48,8 @@ class Occurrence_Model extends ORM {
     'occurrence:fk_taxa_taxon_list:specific' => 'Specific name/epithet (builds binomial name)',
     'occurrence:fk_taxa_taxon_list:external_key' => 'Species or taxon external key',
     'occurrence:fk_taxa_taxon_list:search_code' => 'Species or taxon search code',
-    'occurrence:taxa_taxon_list_id' => 'Species or taxon taxa_taxon_lists.id',
+    // needs to be more complex version so import recognises it as same field as above
+    'occurrence:fk_taxa_taxon_list:id' => 'Species or taxon taxa_taxon_lists.id',
     // Allow details of 4 images to be uploaded in CSV files.
     'occurrence_medium:path:1' => 'Media Path 1',
     'occurrence_medium:caption:1' => 'Media Caption 1',

--- a/application/models/sample.php
+++ b/application/models/sample.php
@@ -48,6 +48,7 @@ class Sample_Model extends ORM_Tree {
     'survey_id' => 'Survey ID',
     'website_id' => 'Website ID',
     // extra lookup options
+    'sample:fk_location:id' => 'Location Indicia ID',
     'sample:fk_location:code' => 'Location Code',
     'sample:fk_location:external_key' => 'Location external key',
     'sample:fk_parent:external_key' => 'Parent sample external key',

--- a/modules/indicia_svc_import/controllers/services/import.php
+++ b/modules/indicia_svc_import/controllers/services/import.php
@@ -659,9 +659,9 @@ class Import_Controller extends Service_Base_Controller {
         foreach ($saveArray as $field => $value) {
           $fkLocationSet |= (!empty($value) && strpos($field, 'sample:fk_location:') !== FALSE);
         }
-        if ($fkLocationSet && empty($saveArray['sample:entered_sef'])) {
-          unset($saveArray['sample:entered_sef']);
-          unset($saveArray['sample:entered_sef_system']);
+        if ($fkLocationSet && empty($saveArray['sample:entered_sref'])) {
+          unset($saveArray['sample:entered_sref']);
+          unset($saveArray['sample:entered_sref_system']);
         }
 
         // Save the record.

--- a/modules/indicia_svc_import/controllers/services/import.php
+++ b/modules/indicia_svc_import/controllers/services/import.php
@@ -654,6 +654,16 @@ class Import_Controller extends Service_Base_Controller {
           }
         }
 
+        // Special case for samples: the sref system is fixed for the file, but is not required in location_id provided
+        $fkLocationSet = !empty($saveArray['sample:fk_location']);
+        foreach ($saveArray as $field => $value) {
+          $fkLocationSet |= (!empty($value) && strpos($field, 'sample:fk_location:') !== FALSE);
+        }
+        if ($fkLocationSet && empty($saveArray['sample:entered_sef'])) {
+          unset($saveArray['sample:entered_sef']);
+          unset($saveArray['sample:entered_sef_system']);
+        }
+
         // Save the record.
         $model->set_submission_data($saveArray, TRUE);
         /*


### PR DESCRIPTION
Following changes to import:
Samples: Don't force entry of an sref if a location id provided
Samples: Allow the location to be referenced by its Indicia ID
Locations: Allow the parent location to be referenced by its Indicia ID
Occurrences: Don't force entry of an taxon name when specifying the taxon by its Indicia TTLID,

See https://github.com/BiologicalRecordsCentre/UKBMS-online/issues/125