### PR TITLE
Mapmate download format

### DIFF
--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1776,8 +1776,12 @@ class Rest_Controller extends Controller {
    */
   private function esGetSpecialFieldOrganismQuantity(array $doc, array $params) {
     $format = !empty($params) ? $params[0] : "";
-    $zero = isset($doc['occurrence']['zero_abundance']) ? $doc['occurrence']['zero_abundance'] : false;
-    $quantity = isset($doc['occurrence']['organism_quantity']) ? $doc['occurrence']['organism_quantity'] : '';
+    $quantity = !empty($doc['occurrence']['organism_quantity']) ? $doc['occurrence']['organism_quantity'] : '';
+    if (!empty($doc['occurrence']['zero_abundance']) && $doc['occurrence']['zero_abundance'] !== 'false') {
+      $zero = True;
+    } else {
+      $zero = False;
+    }
     switch($format) {
       case "mapmate":
         // Mapmate will only accept integer values and uses a value 

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -997,6 +997,7 @@ class Rest_Controller extends Controller {
       ['caption' => 'Site', 'field' => 'location.verbatim_locality'],
       ['caption' => 'Gridref', 'field' => 'location.output_sref'],
       ['caption' => 'VC', 'field' => '#higher_geography:Vice County:code#'],
+      ['caption' => 'MMVC', 'field' => '#mapmate_vc#'],
       ['caption' => 'Recorder', 'field' => 'event.recorded_by'],
       ['caption' => 'Determiner', 'field' => 'identification.identified_by'],
       ['caption' => 'Date', 'field' => '#mapmate_date#'],
@@ -1096,6 +1097,9 @@ class Rest_Controller extends Controller {
         elseif ($field === '#mapmate_date#') {
           $fields[] = 'event.date_start';
           $fields[] = 'event.date_end';
+        }
+        elseif ($field === '#mapmate_vc#') {
+          $fields[] = 'location.higher_geography';
         }
         elseif (preg_match('/^#(lat_lon|lat|lon)#$/', $field) || preg_match('/^#(lat|lon):(.*)#$/', $field)) {
           $fields[] = 'location.point';
@@ -1722,6 +1726,33 @@ class Rest_Controller extends Controller {
     }
     else {
       return '';
+    }
+  }
+
+  /**
+   * Special field handler for Elasticsearch location VC number formatted for MapMate.
+   *
+   * Converts Vice County code to formats preferred by MapMate
+   * for inclusion in CSV output suitable for MapMate import.
+   *
+   * @param array $doc
+   *   Elasticsearch document.
+   *
+   * @return string
+   *   VC number. If Irish, it is prefixed with H. If unknown, set to zero.
+   */
+  private function esGetSpecialFieldMapmateVc(array $doc) {
+    // No need to duplicate work of esGetSpecialFieldHigherGeography.
+    // Use that function to format the date initially then
+    // modify for MapMate.
+    $vc = $this->esGetSpecialFieldHigherGeography($doc, array("Vice County", "code"));
+    if ($vc === "") {
+      // Where unable to assign VC, return 0. This will 
+      // cause MapMate to work out the VC itself..
+      return "0";
+    } 
+    else {
+      return $vc;
     }
   }
 

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1102,7 +1102,7 @@ class Rest_Controller extends Controller {
         elseif ($field === '#mapmate_vc#') {
           $fields[] = 'location.higher_geography';
         }
-        elseif ($field === '#organism_quantity#') {
+        elseif (preg_match('/^#organism_quantity(.*)#$/', $field)) {
           $fields[] = 'occurrence.organism_quantity';
           $fields[] = 'occurrence.zero_abundance';
         }

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1582,7 +1582,7 @@ class Rest_Controller extends Controller {
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
     $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
-    return  DateTime::format($params[1], $dt);
+    return  $dt.format($params[1]);
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1776,14 +1776,14 @@ class Rest_Controller extends Controller {
    */
   private function esGetSpecialFieldOrganismQuantity(array $doc, array $params) {
     $format = !empty($params) ? $params[0] : "";
-    $zero = isset($doc['occurrence']['zero_abundance']) ? $doc['occurrence']['zero_abundance'] : 'false';
+    $zero = isset($doc['occurrence']['zero_abundance']) ? $doc['occurrence']['zero_abundance'] : false;
     $quantity = isset($doc['occurrence']['organism_quantity']) ? $doc['occurrence']['organism_quantity'] : '';
     switch($format) {
       case "mapmate":
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.
-        if ($zero === 'true' || $quantity === '0') {
+        if ($zero || $quantity === '0') {
           return -7;
         }
         elseif(preg_match('/^\d+$/', $quantity)) {

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1784,6 +1784,7 @@ class Rest_Controller extends Controller {
     }
     switch($format) {
       case "mapmate":
+        return $zero;
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1582,7 +1582,8 @@ class Rest_Controller extends Controller {
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
     $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
-    return  $dt->format($params[1]);
+    // $dt->format($params[1]);
+    return  "$dtvalue # $params[1]";
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1582,7 +1582,7 @@ class Rest_Controller extends Controller {
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
     $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
-    return  $dt.format($params[1]);
+    return  $dt->format($params[1]);
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1010,8 +1010,8 @@ class Rest_Controller extends Controller {
       ['caption' => 'RecordKey', 'field' => '_id'],
       ['caption' => 'NonNumericQuantity', 'field' => '#organism_quantity:non-integer#'],
       ['caption' => 'Habitat', 'field' => 'event.habitat'],
-      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G:i:s#'],
-      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G:i:s#'],
+      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G-i-s#'],
+      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G-i-s#'],
       ['caption' => 'Verification status 1', 'field' => 'identification.verification_status'],
       ['caption' => 'Verification status 2', 'field' => '#null_if_zero:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => 'identification.query'],
@@ -1146,7 +1146,7 @@ class Rest_Controller extends Controller {
         elseif (preg_match('/^#null_if_zero:([a-z_]+(\.[a-z_]+)*)#$/', $field, $matches)) {
           $fields[] = $matches[1];
         }
-        elseif (preg_match('/^#datetime:([a-z_]+(\.[a-z_]+)*)#$/', $field, $matches)) {
+        elseif (preg_match('/^#datetime:([a-z_]+(\.[a-z_]+)*):.*#$/', $field, $matches)) {
           $fields[] = $matches[1];
         }
       }

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1010,8 +1010,8 @@ class Rest_Controller extends Controller {
       ['caption' => 'RecordKey', 'field' => '_id'],
       ['caption' => 'NonNumericQuantity', 'field' => '#organism_quantity:non-integer#'],
       ['caption' => 'Habitat', 'field' => 'event.habitat'],
-      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G-i-s#'],
-      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G-i-s#'],
+      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H^i^s#'], // Can't use : in format spec here - use ^ instead which is translated to :
+      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G^i^s#'], // Can't use : in format spec here - use ^ instead which is translated to :
       ['caption' => 'Verification status 1', 'field' => 'identification.verification_status'],
       ['caption' => 'Verification status 2', 'field' => '#null_if_zero:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => 'identification.query'],
@@ -1582,10 +1582,12 @@ class Rest_Controller extends Controller {
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
     $dt = DateTime::createFromFormat("Y-m-d G:i:s.u", $dtvalue);
+    // Replace any ^ characters in format with :
+    $format = str_replace("^", ":", $params[1]);
     if ($dt === FALSE) {
       return  $dtvalue;
     } else {
-      return $dt->format($params[1]);
+      return $dt->format($format);
     }
   }
 

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1581,9 +1581,12 @@ class Rest_Controller extends Controller {
       return 'Incorrect params for Datetime field';
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
-    $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
-    // $dt->format($params[1]);
-    return  "$dtvalue # $params[1]";
+    $dt = DateTime::createFromFormat("Y-m-d G:i:s.u", $dtvalue);
+    if ($dt === FALSE) {
+      return  $dtvalue;
+    } else {
+      return $dt->format($params[1]);
+    }
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1010,8 +1010,8 @@ class Rest_Controller extends Controller {
       ['caption' => 'RecordKey', 'field' => '_id'],
       ['caption' => 'NonNumericQuantity', 'field' => '#organism_quantity:non-integer#'],
       ['caption' => 'Habitat', 'field' => 'event.habitat'],
-      // ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G:i:s#'],
-      // ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G:i:s#'],
+      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G:i:s#'],
+      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G:i:s#'],
       ['caption' => 'Verification status 1', 'field' => 'identification.verification_status'],
       ['caption' => 'Verification status 2', 'field' => '#null_if_zero:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => 'identification.query'],
@@ -1559,6 +1559,30 @@ class Rest_Controller extends Controller {
     else {
       return '';
     }
+  }
+
+  /**
+   * Special field handler ES datetime fields to output with provided format.
+   *
+   * Return the datetime as a string formatted as specified.
+   *
+   * @param array $doc
+   *   Elasticsearch document.
+   * @param array $params
+   *   Provided parameters: 
+   *   1. ES field
+   *   2. datetime format
+   *
+   * @return string
+   *   Formatted string
+   */
+  private function esGetSpecialFieldDatetime(array $doc, array $params) {
+    if (count($params) !== 2) {
+      return 'Incorrect params for Datetime field';
+    }
+    $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
+    $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
+    return  DateTime::format($params[1], $dt);
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1652,7 +1652,7 @@ class Rest_Controller extends Controller {
     // No need to duplicate work of esGetSpecialFieldEventDate.
     // Use that function to format the date initially then
     // modify for MapMate.
-    $date = esGetSpecialFieldEventDate($doc);
+    $date = $this->esGetSpecialFieldEventDate($doc);
     if (startsWith($date, "Before ")) {
       // Mapmate can't deal with unbound ranges
       // - replace with date of known bound.

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1785,7 +1785,7 @@ class Rest_Controller extends Controller {
     }
     switch($format) {
       case "mapmate":
-        return $zero ? "zero" : "not zero";
+        return $doc['occurrence']['zero_abundance'];
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1779,12 +1779,13 @@ class Rest_Controller extends Controller {
     $quantity = !empty($doc['occurrence']['organism_quantity']) ? $doc['occurrence']['organism_quantity'] : '';
     if (!empty($doc['occurrence']['zero_abundance']) && $doc['occurrence']['zero_abundance'] !== 'false') {
       $zero = True;
-    } else {
+    } 
+    else {
       $zero = False;
     }
     switch($format) {
       case "mapmate":
-        return $zero;
+        return $zero ? "zero" : "not zero";
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1519,7 +1519,7 @@ class Rest_Controller extends Controller {
     };
   }
 
-   /**
+  /**
    * Special field handler returns an empty string. This is useful
    * where the output CSV must contain a column to which no
    * useful data can be mapped.
@@ -1534,7 +1534,7 @@ class Rest_Controller extends Controller {
     return '';
   }
 
-   /**
+  /**
    * Special field handler for Elasticsearch to combine
    * the sample and occurrence comment.
    *
@@ -1736,7 +1736,7 @@ class Rest_Controller extends Controller {
     }
   }
 
-   /**
+  /**
    * Special field handler for Elasticsearch event dates compatible for MapMate.
    *
    * Converts event.date_from and event.date_to to a readable date string, e.g.
@@ -1844,7 +1844,7 @@ class Rest_Controller extends Controller {
     $vc = $this->esGetSpecialFieldHigherGeography($doc, array("Vice County", "code"));
     if ($vc === "") {
       // Where unable to assign VC, return 0. This will 
-      // cause MapMate to work out the VC itself..
+      // cause MapMate to work out the VC itself.
       return "0";
     } 
     else {
@@ -1852,7 +1852,7 @@ class Rest_Controller extends Controller {
     }
   }
 
- /**
+  /**
    * Special field handler for Elasticsearch sex formatted for MapMate.
    *
    * Converts occurrence.sex to values acceptable for
@@ -1885,7 +1885,7 @@ class Rest_Controller extends Controller {
     }
   }
 
- /**
+  /**
    * Special field handler for Elasticsearch life_stage formatted for MapMate.
    *
    * Converts occurrence.life_stage to values acceptable for

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1663,7 +1663,7 @@ class Rest_Controller extends Controller {
       // - replace with date of known bound.
       return substr($date, 6);
     }
-    elseif (strpos($a, ' to ') !== false) {
+    elseif (strpos($date, ' to ') !== false) {
       // Mapmate uses a hyphen in date ranges.
       return str_replace(" to ","-",$date);
     }

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1653,12 +1653,12 @@ class Rest_Controller extends Controller {
     // Use that function to format the date initially then
     // modify for MapMate.
     $date = $this->esGetSpecialFieldEventDate($doc);
-    if (startsWith($date, "Before ")) {
+    if (substr($date,0,7) === "Before ") {
       // Mapmate can't deal with unbound ranges
       // - replace with date of known bound.
       return substr($date, 7);
     } 
-    elseif (startsWith($date, "After ")) {
+    elseif (substr($date,0,6) === "After ") {
       // Mapmate can't deal with unbound ranges
       // - replace with date of known bound.
       return substr($date, 6);

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1797,6 +1797,14 @@ class Rest_Controller extends Controller {
         else {
           return '';
         }
+      case "integer":
+        // Only return the value if it is an iteger.
+        if(preg_match('/^\d+$/', $quantity)) {
+          return $quantity;
+        }
+        else {
+          return '';
+        }
       case "non-integer":
         // Only return the value if it is not an iteger.
         if(!preg_match('/^\d+$/', $quantity)) {

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1785,7 +1785,6 @@ class Rest_Controller extends Controller {
     }
     switch($format) {
       case "mapmate":
-        return $doc['occurrence']['zero_abundance'];
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.


### PR DESCRIPTION
John - could you take a look at the stuff I've added to address Martin's requests for the MapMate download format. I've added a number of special field handlers specific to MM. Where that is the case I've used 'mapmate' in their names. Some required special fields seemed to be have potential to be used more widely, e.g. the datetime format, so for those I've not used 'mapmate' in their names. Would appreciate you having a look to see if there are any non-optimal coding patterns etc. 

I've tested on dev Warehouse from my local iForm instance which links to it.

There's a related pull request on client helpers to add mapmate format to download format selector.