### PR TITLE
Iss 886 mapmate and backward compat download format handling

### DIFF
--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1776,8 +1776,12 @@ class Rest_Controller extends Controller {
    */
   private function esGetSpecialFieldOrganismQuantity(array $doc, array $params) {
     $format = !empty($params) ? $params[0] : "";
-    $zero = isset($doc['occurrence']['zero_abundance']) ? $doc['occurrence']['zero_abundance'] : false;
-    $quantity = isset($doc['occurrence']['organism_quantity']) ? $doc['occurrence']['organism_quantity'] : '';
+    $quantity = !empty($doc['occurrence']['organism_quantity']) ? $doc['occurrence']['organism_quantity'] : '';
+    if (!empty($doc['occurrence']['zero_abundance']) && $doc['occurrence']['zero_abundance'] !== 'false') {
+      $zero = True;
+    } else {
+      $zero = False;
+    }
     switch($format) {
       case "mapmate":
         // Mapmate will only accept integer values and uses a value 

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1050,9 +1050,9 @@ class Rest_Controller extends Controller {
       ['caption' => 'Verification status 2', 'field' => '#backward:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => '#backward:identification.query#'],
       ['caption' => 'Verifier', 'field' => 'identification.verifier.name'],
-      ['caption' => 'Verified on', 'field' => 'identification.verified_on'],
+      ['caption' => 'Verified on', 'field' => '#datetime:identification.verified_on:d/m/Y H^i#'], // Can't use : in format spec here - use ^ instead which is translated to :
       ['caption' => 'Licence', 'field' => 'metadata.licence_code'],
-      ['caption' => 'Automated checks', 'field' => '#backward:identification.verification_substatus#'], // Output probably different from easy download?
+      ['caption' => 'Automated checks', 'field' => 'identification.auto_checks.result'], 
     ],
     "mapmate" => [
       ['caption' => 'Taxon', 'field' => 'taxon.accepted_name'],

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -997,6 +997,7 @@ class Rest_Controller extends Controller {
       ['caption' => 'Site', 'field' => 'location.verbatim_locality'],
       ['caption' => 'Gridref', 'field' => 'location.output_sref'],
       ['caption' => 'VC', 'field' => '#higher_geography:Vice County:code#'],
+      ['caption' => 'MMVC', 'field' => '#mapmate_vc#'],
       ['caption' => 'Recorder', 'field' => 'event.recorded_by'],
       ['caption' => 'Determiner', 'field' => 'identification.identified_by'],
       ['caption' => 'Date', 'field' => '#mapmate_date#'],
@@ -1096,6 +1097,9 @@ class Rest_Controller extends Controller {
         elseif ($field === '#mapmate_date#') {
           $fields[] = 'event.date_start';
           $fields[] = 'event.date_end';
+        }
+        elseif ($field === '#mapmate_vc#') {
+          $fields[] = 'location.higher_geography';
         }
         elseif (preg_match('/^#(lat_lon|lat|lon)#$/', $field) || preg_match('/^#(lat|lon):(.*)#$/', $field)) {
           $fields[] = 'location.point';
@@ -1722,6 +1726,33 @@ class Rest_Controller extends Controller {
     }
     else {
       return '';
+    }
+  }
+
+  /**
+   * Special field handler for Elasticsearch location VC number formatted for MapMate.
+   *
+   * Converts Vice County code to formats preferred by MapMate
+   * for inclusion in CSV output suitable for MapMate import.
+   *
+   * @param array $doc
+   *   Elasticsearch document.
+   *
+   * @return string
+   *   VC number. If Irish, it is prefixed with H. If unknown, set to zero.
+   */
+  private function esGetSpecialFieldMapmateVc(array $doc) {
+    // No need to duplicate work of esGetSpecialFieldHigherGeography.
+    // Use that function to format the date initially then
+    // modify for MapMate.
+    $vc = $this->esGetSpecialFieldHigherGeography($doc, array("Vice County", "code"));
+    if ($vc === "") {
+      // Where unable to assign VC, return 0. This will 
+      // cause MapMate to work out the VC itself..
+      return "0";
+    } 
+    else {
+      return $vc;
     }
   }
 

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1046,7 +1046,7 @@ class Rest_Controller extends Controller {
       ['caption' => 'Images', 'field' => '#occurrence_media#'],
       ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H^i#'], // Can't use : in format spec here - use ^ instead which is translated to :
       ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y H^i#'], // Can't use : in format spec here - use ^ instead which is translated to :
-      ['caption' => 'Verification status 1', 'field' => '#backward:identification.verification_status"'],
+      ['caption' => 'Verification status 1', 'field' => '#backward:identification.verification_status#"'],
       ['caption' => 'Verification status 2', 'field' => '#backward:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => '#backward:identification.query#'],
       ['caption' => 'Verifier', 'field' => 'identification.verifier.name'],

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1606,28 +1606,6 @@ class Rest_Controller extends Controller {
   }
 
   /**
-   * Special field handler to format record ID.
-   *
-   * @param array $doc
-   *   Elasticsearch document.
-   *
-   * @return string
-   *   Formatted ID value.
-   */
-  private function esGetSpecialFieldId(array $doc, array $params) {
-    if (count($params) !== 1) {
-      return 'Incorrect params for formatted ID field';
-    }
-    if ($params[0] === 'easy') {
-      // Provides backward compatibility with pre-ES download format ('easy download').
-      return preg_replace('/^brc1\|/', 'iBRC', $doc['_id']);
-    }
-    else {
-      return $doc['_id'];
-    }
-  }
-
-  /**
    * Special field handler for Elasticsearch to combine
    * the sample and occurrence comment.
    *

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1008,9 +1008,9 @@ class Rest_Controller extends Controller {
     ],
     "easy-download" => [
       ['caption' => 'ID', 'field' => 'id'],
-      ['caption' => 'RecordKey', 'field' => '#backward:_id#'],
+      ['caption' => 'RecordKey', 'field' => '#id:easy#'],
       ['caption' => 'External key', 'field' => 'occurrence_external_key'],
-      ['caption' => 'Source', 'field' => '#backward:datasource_code#'],
+      ['caption' => 'Source', 'field' => '#datasource_code:with_group#'],
       ['caption' => 'Species', 'field' => 'taxon.accepted_name'],
       ['caption' => 'Common name', 'field' => 'taxon.vernacular_name'],
       ['caption' => 'Taxon group', 'field' => 'taxon.group'],
@@ -1022,10 +1022,10 @@ class Rest_Controller extends Controller {
       ['caption' => 'Original map ref', 'field' => 'location.input_sref'],
       ['caption' => 'Latitude', 'field' => '#lat:decimal#'],
       ['caption' => 'Longitude', 'field' => '#lon:decimal#'],
-      ['caption' => 'Projection', 'field' => '#backward:location.input_sref_system#'],
+      ['caption' => 'Projection', 'field' => '#sref_system:location.input_sref_system:alphanumeric#'],
       ['caption' => 'Precision', 'field' => 'location.coordinate_uncertainty_in_meters'],
       ['caption' => 'Output map ref', 'field' => 'location.output_sref'],
-      ['caption' => 'Projection', 'field' => '#backward:location.output_sref_system#'],
+      ['caption' => 'Projection', 'field' => '#sref_system:location.output_sref_system:alphanumeric#'],
       ['caption' => 'Biotope', 'field' => 'event.habitat'],
       ['caption' => 'VC number', 'field' => '#higher_geography:Vice County:code#'],
       ['caption' => 'Vice County', 'field' => '#higher_geography:Vice County:name#'],
@@ -1046,9 +1046,9 @@ class Rest_Controller extends Controller {
       ['caption' => 'Images', 'field' => '#occurrence_media#'],
       ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H\:i#'],
       ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y H\:i#'],
-      ['caption' => 'Verification status 1', 'field' => '#backward:identification.verification_status#'],
-      ['caption' => 'Verification status 2', 'field' => '#backward:identification.verification_substatus#'],
-      ['caption' => 'Query', 'field' => '#backward:identification.query#'],
+      ['caption' => 'Verification status 1', 'field' => '#verification_status:standard#'],
+      ['caption' => 'Verification status 2', 'field' => '#verification_substatus:standard#'],
+      ['caption' => 'Query', 'field' => '#query:standard#'],
       ['caption' => 'Verifier', 'field' => 'identification.verifier.name'],
       ['caption' => 'Verified on', 'field' => '#datetime:identification.verified_on:d/m/Y H\:i#'],
       ['caption' => 'Licence', 'field' => 'metadata.licence_code'],
@@ -1058,14 +1058,14 @@ class Rest_Controller extends Controller {
       ['caption' => 'Taxon', 'field' => 'taxon.accepted_name'],
       ['caption' => 'Site', 'field' => 'location.verbatim_locality'],
       ['caption' => 'Gridref', 'field' => 'location.output_sref'],
-      ['caption' => 'VC', 'field' => '#mapmate_vc#'],
+      ['caption' => 'VC', 'field' => '#vc:mapmate#'],
       ['caption' => 'Recorder', 'field' => 'event.recorded_by'],
       ['caption' => 'Determiner', 'field' => 'identification.identified_by'],
-      ['caption' => 'Date', 'field' => '#mapmate_date#'],
+      ['caption' => 'Date', 'field' => '#record_date:mapmate#'],
       ['caption' => 'Quantity', 'field' => '#organism_quantity:mapmate#'],
       ['caption' => 'Method', 'field' => 'event.sampling_protocol'],
-      ['caption' => 'Sex', 'field' => '#mapmate_sex#'],
-      ['caption' => 'Stage', 'field' => '#mapmate_life_stage#'],
+      ['caption' => 'Sex', 'field' => '#sex:mapmate#'],
+      ['caption' => 'Stage', 'field' => '#life_stage:mapmate#'],
       ['caption' => 'Status', 'field' => '#blank#'],
       ['caption' => 'Comment', 'field' => '#sample_occurrence_comment#'],
       ['caption' => 'ID', 'field' => 'id'],
@@ -1074,9 +1074,9 @@ class Rest_Controller extends Controller {
       ['caption' => 'Habitat', 'field' => 'event.habitat'],
       ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H\:i\:s#'],
       ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G\:i\:s#'],
-      ['caption' => 'Verification status 1', 'field' => 'identification.verification_status'],
-      ['caption' => 'Verification status 2', 'field' => '#null_if_zero:identification.verification_substatus#'],
-      ['caption' => 'Query', 'field' => 'identification.query'],
+      ['caption' => 'Verification status 1', 'field' => '#verification_status:standard#'],
+      ['caption' => 'Verification status 2', 'field' => '#verification_substatus:standard#'],
+      ['caption' => 'Query', 'field' => '#query:standard#'],
       ['caption' => 'Licence', 'field' => 'metadata.licence_code'],
     ]
   ];
@@ -1155,25 +1155,26 @@ class Rest_Controller extends Controller {
         elseif ($field === '#data_cleaner_icons#') {
           $fields[] = 'identification.auto_checks';
         }
-        elseif ($field === '#datasource_code#') {
+        elseif (preg_match('/^#datasource_code(:.+)*#$/', $field)) {
           $fields[] = 'metadata.website';
           $fields[] = 'metadata.survey';
+          $fields[] = 'metadata.group';
         }
         elseif ($field === '#event_date#') {
           $fields[] = 'event.date_start';
           $fields[] = 'event.date_end';
         }
-        elseif ($field === '#mapmate_date#') {
+        elseif (preg_match('/^#record_date(.*)#$/', $field)) {
           $fields[] = 'event.date_start';
           $fields[] = 'event.date_end';
         }
-        elseif ($field === '#mapmate_vc#') {
+        elseif (preg_match('/^#vc(.*)#$/', $field)) {
           $fields[] = 'location.higher_geography';
         }
-        elseif ($field === '#mapmate_sex#') {
+        elseif (preg_match('/^#sex(.*)#$/', $field)) {
           $fields[] = 'occurrence.sex';
         }
-        elseif ($field === '#mapmate_life_stage#') {
+        elseif (preg_match('/^#life_stage(.*)#$/', $field)) {
           $fields[] = 'occurrence.life_stage';
         }
         elseif ($field ==='#sample_occurrence_comment#') {
@@ -1199,6 +1200,15 @@ class Rest_Controller extends Controller {
           $fields[] = 'identification';
           $fields[] = 'occurrence.zero_abundance';
         }
+        elseif (preg_match('/^#verification_status(.*)#$/', $field)) {
+          $fields[] = 'identification.verification_status';
+        }
+        elseif (preg_match('/^#verification_substatus(.*)#$/', $field)) {
+          $fields[] = 'identification.verification_substatus';
+        }
+        elseif (preg_match('/^#query(.*)#$/', $field)) {
+          $fields[] = 'identification.query';
+        }
         elseif (preg_match('/^#attr_value:(event|sample|parent_event|occurrence):(\d+)#$/', $field, $matches)) {
           $key = $matches[1] === 'parent_event' ? 'parent_attributes' : 'attributes';
           // Tolerate sample or event for entity parameter.
@@ -1211,15 +1221,8 @@ class Rest_Controller extends Controller {
         elseif (preg_match('/^#datetime:([a-z_]+(\.[a-z_]+)*):.*#$/', $field, $matches)) {
           $fields[] = $matches[1];
         }
-        elseif (preg_match('/^#backward:([a-z_]+(\.[a-z_]+)*)#$/', $field, $matches)) {
-          if ($matches[1] === 'datasource_code') {
-            $fields[] = 'metadata.website';
-            $fields[] = 'metadata.survey';
-            $fields[] = 'metadata.group';
-          } 
-          else {
-            $fields[] = $matches[1];
-          }
+        elseif (preg_match('/^#sref_system:([a-z_]+(\.[a-z_]+)*):.*#$/', $field, $matches)) {
+          $fields[] = $matches[1];
         }
       }
       $postObj->_source = array_values(array_unique($fields));
@@ -1607,6 +1610,28 @@ class Rest_Controller extends Controller {
   }
 
   /**
+   * Special field handler to format record ID.
+   *
+   * @param array $doc
+   *   Elasticsearch document.
+   *
+   * @return string
+   *   Formatted ID value.
+   */
+  private function esGetSpecialFieldId(array $doc, array $params) {
+    if (count($params) !== 1) {
+      return 'Incorrect params for formatted ID field';
+    }
+    if ($params[0] === 'easy') {
+      // Provides backward compatibility with pre-ES download format ('easy download').
+      return preg_replace('/^brc1\|/', 'iBRC', $doc['_id']);
+    }
+    else {
+      return $doc['_id'];
+    }
+  }
+
+  /**
    * Special field handler for Elasticsearch to combine
    * the sample and occurrence comment.
    *
@@ -1657,7 +1682,187 @@ class Rest_Controller extends Controller {
     if ($dt === FALSE) {
       return  $dtvalue;
     } else {
-      return $dt->format($format);
+      return $dt->format($params[1]);
+    }
+  }
+
+  /**
+   * Special field handler for ES spatial ref system fields.
+   *
+   * Return the spatial ref system formatted as specified.
+   *
+   * @param array $doc
+   *   Elasticsearch document.
+   * @param array $params
+   *   Provided parameters: 
+   *   1. ES field
+   *   2. format identifier
+   *
+   * @return string
+   *   Formatted string
+   */
+  private function esGetSpecialFieldSrefSystem(array $doc, array $params) {
+    if (count($params) !== 2) {
+      return 'Incorrect params for sref system field';
+    }
+    $value = strval($this->getRawEsFieldValue($doc, $params[0]));
+    if ($params[1] === 'alphanumeric') {
+      // Ensure that EPSG codes are converted to alphanumeric string.
+      // Provides backward compatibility with pre-ES downloads.
+      if ($value === '4326') {
+        return 'WGS84';
+      }
+      else if ($value === '27700') {
+        return 'OSGB36';
+      }
+      else {
+        return strtoupper($value);
+      }
+    }
+    else {
+      return $value;
+    }
+  }
+
+  /**
+   * Special field handler for ES verification status.
+   *
+   * Return the verification status formatted as specified.
+   *
+   * @param array $doc
+   *   Elasticsearch document.
+   * @param array $params
+   *   An identifier for the format.
+   *
+   * @return string
+   *   Formatted string
+   */
+  private function esGetSpecialFieldVerificationStatus(array $doc, array $params) {
+    if (count($params) !== 1) {
+      return 'Incorrect params for verification status field';
+    }
+    $value = $this->getRawEsFieldValue($doc, 'identification.verification_status');
+    if ($params[0] === 'standard') {
+      // Provides backward compatibility with pre-ES downloads.
+      if($value === 'V'){
+        return 'Accepted';
+      }
+      elseif ($value === 'C'){
+        return 'Unconfirmed';
+      }
+      elseif ($value === 'R'){
+        return 'Rejected';
+      }
+      elseif ($value === 'I'){
+        return 'Input still in progress';
+      }
+      elseif ($value === 'D'){
+        return 'Queried';
+      }
+      elseif ($value === 'S'){
+        return 'Awaiting check';
+      }
+      else {
+        return $value;
+      }
+    }
+    else {
+      return $value;
+    }
+  }
+
+  /**
+   * Special field handler for ES verification status.
+   *
+   * Return the verification status formatted as specified.
+   *
+   * @param array $doc
+   *   Elasticsearch document.
+   * @param array $params
+   *   An identifier for the format.
+   *
+   * @return string
+   *   Formatted string
+   */
+  private function esGetSpecialFieldVerificationSubstatus(array $doc, array $params) {
+    if (count($params) !== 1) {
+      return 'Incorrect params for verification substatus field';
+    }
+    $status = $this->getRawEsFieldValue($doc, 'identification.verification_status');
+    $value = $this->getRawEsFieldValue($doc, 'identification.verification_substatus');
+    if ($params[0] === 'standard') {
+      // Provides backward compatibility with pre-ES downloads.
+      if($status === 'V'){
+        if ($value === '1') {
+          return 'Correct';
+        }
+        elseif ($value === '2') {
+          return 'Considered correct';
+        }
+        else {
+          return NULL;
+        }
+      }
+      elseif ($status === 'C'){
+        if ($value === '3') {
+          return 'Plausible';
+        }
+        else {
+          return 'Not reviewed';
+        }
+      }
+      elseif ($status === 'R'){
+        if ($value === '4') {
+          return 'Unable to verify';
+        }
+        elseif ($value === '5') {
+          return 'Incorrect';
+        }
+        else {
+          return NULL;
+        }
+      }
+      else {
+        return NULL;
+      }
+    }
+    else {
+      return $value;
+    }
+  }
+
+  /**
+   * Special field handler for ES identification query status.
+   *
+   * Return the identification query status formatted as specified.
+   *
+   * @param array $doc
+   *   Elasticsearch document.
+   * @param array $params
+   *   An identifier for the format.
+   *
+   * @return string
+   *   Formatted string
+   */
+  private function esGetSpecialFieldQuery(array $doc, array $params) {
+    if (count($params) !== 1) {
+      return 'Incorrect params for query field';
+    }
+    $value = $this->getRawEsFieldValue($doc, 'identification.query');
+    if ($params[0] === 'standard') {
+      // Provides backward compatibility with pre-ES downloads.
+      if($value === 'A'){
+        return 'Answered';
+      }
+      elseif ($value === 'Q'){
+        return 'Queried';
+      }
+      else {
+        return $value;
+      }
+    }
+    else {
+      return $value;
     }
   }
 
@@ -1755,12 +1960,29 @@ class Rest_Controller extends Controller {
    *   Elasticsearch document.
    *
    * @return string
-   *   Formatted value including website and survey dataset info.
+   *   Formatted value including website, survey dataset and,
+   *   optionally, group info.
    */
-  private function esGetSpecialFieldDatasourceCode(array $doc) {
+  private function esGetSpecialFieldDatasourceCode(array $doc, $params) {
+    if (count($params) > 1) {
+      return 'Incorrect params for non-standard datasource field (must be 0 or 1)';
+    }
     $w = $doc['metadata']['website'];
     $s = $doc['metadata']['survey'];
-    return "$w[id] ($w[title]) | $s[id] ($s[title])";
+    if (count($params) && $params[0] === 'with_group') {
+      // Provides backward compatibility with pre-ES downloads.
+      if (isset($doc['metadata']['group'])) {
+        $g = $doc['metadata']['group'];
+        return "$w[title] | $s[title] | $g[title]";
+      }
+      else {
+        return "$w[title] | $s[title]";
+      }
+    }
+    else {
+      // Default format uses id and title for both website and dataset.
+      return "$w[id] ($w[title]) | $s[id] ($s[title])";
+    }
   }
 
   /**
@@ -1806,36 +2028,45 @@ class Rest_Controller extends Controller {
     }
   }
 
+
   /**
-   * Special field handler for Elasticsearch event dates compatible for MapMate.
+   * Special field handler for Elasticsearch event dates with format options.
    *
-   * Converts event.date_from and event.date_to to a readable date string, e.g.
-   * for inclusion in CSV output suitable for MapMate import.
-   *
+   * Converts event.date_from and/or event.date_to to a date string
+   * with the identified format.
+   * 
    * @param array $doc
    *   Elasticsearch document.
+   * @param array $params
+   *   An identifier for the format.
    *
    * @return string
-   *   MapMate formatted date.
+   *   Formatted date.
    */
-  private function esGetSpecialFieldMapmateDate(array $doc) {
-    // No need to duplicate work of esGetSpecialFieldEventDate.
-    // Use that function to format the date initially then
-    // modify for MapMate.
-    $date = $this->esGetSpecialFieldEventDate($doc);
-    if (substr($date,0,7) === 'Before ') {
-      // Mapmate can't deal with unbound ranges
-      // - replace with date of known bound.
-      return substr($date, 7);
-    } 
-    elseif (substr($date,0,6) === 'After ') {
-      // Mapmate can't deal with unbound ranges
-      // - replace with date of known bound.
-      return substr($date, 6);
+  private function esGetSpecialFieldRecordDate(array $doc, array $params) {
+    if (count($params) !== 1) {
+      return 'Incorrect params for formatted date';
     }
-    elseif (strpos($date, ' to ') !== false) {
-      // Mapmate uses a hyphen in date ranges.
-      return str_replace(' to ','-',$date);
+    $date = $this->esGetSpecialFieldEventDate($doc);
+    if ($params[0] === 'mapmate') {
+      // Provides compatibility for import to MapMate.
+      if (substr($date,0,7) === 'Before ') {
+        // Mapmate can't deal with unbound ranges
+        // - replace with date of known bound.
+        return substr($date, 7);
+      } 
+      elseif (substr($date,0,6) === 'After ') {
+        // Mapmate can't deal with unbound ranges
+        // - replace with date of known bound.
+        return substr($date, 6);
+      }
+      elseif (strpos($date, ' to ') !== false) {
+        // Mapmate uses a hyphen in date ranges.
+        return str_replace(' to ','-',$date);
+      }
+      else {
+        return $date;
+      }
     }
     else {
       return $date;
@@ -1896,226 +2127,137 @@ class Rest_Controller extends Controller {
   }
 
   /**
-   * Special field handler for Elasticsearch location VC number formatted for MapMate.
+   * Special field handler for Elasticsearch location VC with format options.
    *
-   * Converts Vice County code to values required by MapMate
-   * for inclusion in CSV output suitable for MapMate import.
-   *
+   * Converts Vice County code to values as specified in format option.
+   * 
    * @param array $doc
    *   Elasticsearch document.
+   * @param array $params
+   *   An identifier for the format.
    *
    * @return string
-   *   VC number. If unknown, set to zero.
+   *   Formatted VC.
    */
-  private function esGetSpecialFieldMapmateVc(array $doc) {
-    // No need to duplicate work of esGetSpecialFieldHigherGeography.
-    // Use that function to get the VC number initially then
-    // modify for MapMate.
-    $vc = $this->esGetSpecialFieldHigherGeography($doc, array('Vice County', 'code'));
-    if ($vc === '') {
-      // Where unable to assign VC, return 0. This will 
-      // cause MapMate to work out the VC itself.
-      return '0';
-    } 
-    else {
-      return $vc;
-    }
-  }
-
-  /**
-   * Special field handler for Elasticsearch sex formatted for MapMate.
-   *
-   * Converts occurrence.sex to values acceptable for
-   * inclusion in CSV output suitable for MapMate import.
-   *
-   * @param array $doc
-   *   Elasticsearch document.
-   *
-   * @return string
-   *   MapMate Sex code.
-   */
-  private function esGetSpecialFieldMapmateSex(array $doc) {
-    $sex = isset($doc['occurrence']['sex']) ? strtolower($doc['occurrence']['sex']) : '';
-    switch($sex) {
-      case 'female':
-        return 'f';
-
-      case 'male':
-        return 'm';
-
-      case 'mixed':
-        return 'g';
-
-      case 'queen':
-        return 'q';
-
-      case 'not recorded':
-      case 'not known':
-      case 'unknown':
-      case 'unsexed:':
-        return 'u';
-
-      default:
-        return $sex;
-    }
-  }
-
-  /**
-   * Special field handler for Elasticsearch life_stage formatted for MapMate.
-   *
-   * Converts occurrence.life_stage to values acceptable for
-   * inclusion in CSV output suitable for MapMate import.
-   *
-   * @param array $doc
-   *   Elasticsearch document.
-   *
-   * @return string
-   *   MapMate Stage value.
-   */
-  private function esGetSpecialFieldMapmateLifeStage(array $doc) {
-    $stage = isset($doc['occurrence']['life_stage']) ? strtolower($doc['occurrence']['life_stage']) : '';
-    switch($stage) {
-      case 'adult':
-      case 'adults':
-      case 'adult female':
-      case 'adult male':
-        return 'Adult';
-
-      case 'larva':
-        return 'Larval';
-
-      case 'not recorded':
-        return 'Not recorded';
-
-      case 'pre-adult':
-        return 'Subadult';
-
-      case 'In flower':
-        return 'Flowering';
-
-      default:
-        return $stage;
-    }
-  }
-
-  /**
-   * Special field handler to provide backward-compatible (easy download) 
-   * formats for several fields.
-   *
-   * @param array $doc
-   *   Elasticsearch document.
-   *
-   * @return string
-   *   Backward compatible string value.
-   */
-  private function esGetSpecialFieldBackward(array $doc, array $params) {
+  private function esGetSpecialFieldVc(array $doc, array $params) {
     if (count($params) !== 1) {
-      return 'Incorrect params for backward compatibility field';
+      return 'Incorrect params for formatted VC';
     }
-    $field = $params[0];
-    switch($field) {
-      case '_id':
-        return preg_replace('/^brc1\|/', 'iBRC', $doc['_id']);
+    $vcnum = $this->esGetSpecialFieldHigherGeography($doc, array('Vice County', 'code'));
+    if ($params[0] === 'mapmate') {
+      // Provides compatibility for import to MapMate
+      if ($vcnum === '') {
+        // Where unable to assign VC, return 0. This will 
+        // cause MapMate to work out the VC itself.
+        return '0';
+      } 
+      elseif(strpos($vcnum, '|') > 0) {
+        // More than one VC returned, set to zer to let
+        // MapMate decide where to place the record.
+        return '0';
+      }
+      else {
+        return $vcnum;
+      }
+    }
+    else {
+      return vcnum;
+    }
+  }
 
-      case 'location.input_sref_system':
-      case 'location.output_sref_system':
-        $value = strval($this->getRawEsFieldValue($doc, $field));
-        if ($value === '4326') {
-          return 'WGS84';
-        }
-        else if ($value === '27700') {
-          return 'OSGB36';
-        }
-        else {
-          return strtoupper($value);
-        }
+  /**
+   * Special field handler for Elasticsearch sex with format options.
+   *
+   * Converts occurrence.sex to values as specified in format option.
+   * 
+   * @param array $doc
+   *   Elasticsearch document.
+   * @param array $params
+   *   An identifier for the format.
+   *
+   * @return string
+   *   Formatted sex.
+   */
+  private function esGetSpecialFieldSex(array $doc, array $params) {
+    if (count($params) !== 1) {
+      return 'Incorrect params for formatted sex';
+    }
+    $value = isset($doc['occurrence']['sex']) ? strtolower($doc['occurrence']['sex']) : '';
+    if ($params[0] === 'mapmate') {
+      // Provides compatibility for import to MapMate
+      switch($value) {
+        case 'female':
+          return 'f';
 
-      case 'datasource_code':
-        $w = $doc['metadata']['website']['title'];
-        $s = $doc['metadata']['survey']['title'];
-        if (isset($doc['metadata']['group'])) {
-          $g = $doc['metadata']['group']['title'];
-          return "$w | $s | $g";
-        }
-        else {
-          return "$w | $s";
-        }
+        case 'male':
+          return 'm';
 
-      case 'identification.verification_status':
-        $value = $this->getRawEsFieldValue($doc, $field);
-        if($value === 'V'){
-          return 'Accepted';
-        }
-        elseif ($value === 'C'){
-          return 'Unconfirmed';
-        }
-        elseif ($value === 'R'){
-          return 'Rejected';
-        }
-        elseif ($value === 'I'){
-          return 'Input still in progress';
-        }
-        elseif ($value === 'D'){
-          return 'Queried';
-        }
-        elseif ($value === 'S'){
-          return 'Awaiting check';
-        }
-        else {
+        case 'mixed':
+          return 'g';
+
+        case 'queen':
+          return 'q';
+
+        case 'not recorded':
+        case 'not known':
+        case 'unknown':
+        case 'unsexed:':
+          return 'u';
+
+        default:
           return $value;
-        }
+      }
+    }
+    else {
+      return $value;
+    }
+  }
 
-      case 'identification.verification_substatus':
-        $status = $this->getRawEsFieldValue($doc, 'identification.verification_status');
-        $value = strval($this->getRawEsFieldValue($doc, $field));
-        if($status === 'V'){
-          if ($value === '1') {
-            return 'correct';
-          }
-          elseif ($value === '2') {
-            return 'Considered correct';
-          }
-          else {
-            return NULL;
-          }
-        }
-        elseif ($status === 'C'){
-          if ($value === '3') {
-            return 'Plausible';
-          }
-          else {
-            return 'Not reviewed';
-          }
-        }
-        elseif ($status === 'R'){
-          if ($value === '4') {
-            return 'Unable to verify';
-          }
-          elseif ($value === '5') {
-            return 'Incorrect';
-          }
-          else {
-            return NULL;
-          }
-        }
-        else {
-          return NULL;
-        }
+  /**
+   * Special field handler for Elasticsearch life stage with format options.
+   *
+   * Converts occurrence.life_stage to values as specified in format option.
+   * 
+   * @param array $doc
+   *   Elasticsearch document.
+   * @param array $params
+   *   An identifier for the format.
+   *
+   * @return string
+   *   Formatted life stage.
+   */
+  private function esGetSpecialFieldLifeStage(array $doc, array $params) {
+    if (count($params) !== 1) {
+      return 'Incorrect params for formatted life stage';
+    }
+    $value = isset($doc['occurrence']['life_stage']) ? strtolower($doc['occurrence']['life_stage']) : '';
+    if ($params[0] === 'mapmate') {
+      // Provides compatibility for import to MapMate
+      switch($value) {
+        case 'adult':
+        case 'adults':
+        case 'adult female':
+        case 'adult male':
+          return 'Adult';
 
-      case 'identification.query':
-        $value = $this->getRawEsFieldValue($doc, $field);
-        if($value === 'A'){
-          return 'Answered';
-        }
-        elseif ($value === 'Q'){
-          return 'Queried';
-        }
-        else {
+        case 'larva':
+          return 'Larval';
+
+        case 'not recorded':
+          return 'Not recorded';
+
+        case 'pre-adult':
+          return 'Subadult';
+
+        case 'In flower':
+          return 'Flowering';
+
+        default:
           return $value;
-        }
-
-      default:
-        return 'No backward compatibility for ' . $field;
+      }
+    }
+    else {
+      return $value;
     }
   }
 
@@ -2447,8 +2589,8 @@ class Rest_Controller extends Controller {
       foreach ($params as &$param) {
         $param = str_replace('EscapedColon', ':', $param);
       }
-      if (count($params) > 0 && strpos($params[0], '_') === 0) {
-        // Resets docSource to root if first param (field) startus with '_'.
+      if ($matches['sourceType'] === 'id') {
+        // Resets docSource to root if special function to format doc ID.
         $docSource = $doc;
       }
       if (method_exists($this, $fn)) {

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1102,7 +1102,7 @@ class Rest_Controller extends Controller {
         elseif ($field === '#mapmate_vc#') {
           $fields[] = 'location.higher_geography';
         }
-        elseif ($field === '#organism_quantity#') {
+        elseif (preg_match('/^#organism_quantity(.*)#$/', $field)) {
           $fields[] = 'occurrence.organism_quantity';
           $fields[] = 'occurrence.zero_abundance';
         }

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1619,13 +1619,13 @@ class Rest_Controller extends Controller {
   private function esGetSpecialFieldSampleOccurrenceComment(array $doc) {
     $oComment = isset($doc['occurrence']['occurrence_remarks']) ? $doc['occurrence']['occurrence_remarks'] : '';
     $sComment = isset($doc['event']['event_remarks']) ? $doc['event']['event_remarks'] : '';
-    if ($oComment !== "" && $sComment !== "") {
+    if ($oComment !== '' && $sComment !== '') {
       return "Record comment: $oComment Sample comment: $sComment";
     }
-    elseif ($oComment !== "") {
+    elseif ($oComment !== '') {
       return "Record comment: $oComment";
     }
-    elseif ($sComment !== "") {
+    elseif ($sComment !== '') {
       return "Sample comment: $sComment";
     }
     else {
@@ -1653,9 +1653,7 @@ class Rest_Controller extends Controller {
       return 'Incorrect params for Datetime field';
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
-    $dt = DateTime::createFromFormat("Y-m-d G:i:s.u", $dtvalue);
-    // Replace any ^ characters in format with :
-    $format = str_replace("^", ":", $params[1]);
+    $dt = DateTime::createFromFormat('Y-m-d G:i:s.u', $dtvalue);
     if ($dt === FALSE) {
       return  $dtvalue;
     } else {
@@ -1825,19 +1823,19 @@ class Rest_Controller extends Controller {
     // Use that function to format the date initially then
     // modify for MapMate.
     $date = $this->esGetSpecialFieldEventDate($doc);
-    if (substr($date,0,7) === "Before ") {
+    if (substr($date,0,7) === 'Before ') {
       // Mapmate can't deal with unbound ranges
       // - replace with date of known bound.
       return substr($date, 7);
     } 
-    elseif (substr($date,0,6) === "After ") {
+    elseif (substr($date,0,6) === 'After ') {
       // Mapmate can't deal with unbound ranges
       // - replace with date of known bound.
       return substr($date, 6);
     }
     elseif (strpos($date, ' to ') !== false) {
       // Mapmate uses a hyphen in date ranges.
-      return str_replace(" to ","-",$date);
+      return str_replace(' to ','-',$date);
     }
     else {
       return $date;
@@ -1913,11 +1911,11 @@ class Rest_Controller extends Controller {
     // No need to duplicate work of esGetSpecialFieldHigherGeography.
     // Use that function to get the VC number initially then
     // modify for MapMate.
-    $vc = $this->esGetSpecialFieldHigherGeography($doc, array("Vice County", "code"));
-    if ($vc === "") {
+    $vc = $this->esGetSpecialFieldHigherGeography($doc, array('Vice County', 'code'));
+    if ($vc === '') {
       // Where unable to assign VC, return 0. This will 
       // cause MapMate to work out the VC itself.
-      return "0";
+      return '0';
     } 
     else {
       return $vc;
@@ -1939,23 +1937,23 @@ class Rest_Controller extends Controller {
   private function esGetSpecialFieldMapmateSex(array $doc) {
     $sex = isset($doc['occurrence']['sex']) ? strtolower($doc['occurrence']['sex']) : '';
     switch($sex) {
-      case "female":
-        return "f";
+      case 'female':
+        return 'f';
 
-      case "male":
-        return "m";
+      case 'male':
+        return 'm';
 
-      case "mixed":
-        return "g";
+      case 'mixed':
+        return 'g';
 
-      case "queen":
-        return "q";
+      case 'queen':
+        return 'q';
 
-      case "not recorded":
-      case "not known":
-      case "unknown":
-      case "unsexed:":
-        return "u";
+      case 'not recorded':
+      case 'not known':
+      case 'unknown':
+      case 'unsexed:':
+        return 'u';
 
       default:
         return $sex;
@@ -1977,23 +1975,23 @@ class Rest_Controller extends Controller {
   private function esGetSpecialFieldMapmateLifeStage(array $doc) {
     $stage = isset($doc['occurrence']['life_stage']) ? strtolower($doc['occurrence']['life_stage']) : '';
     switch($stage) {
-      case "adult":
-      case "adults":
-      case "adult female":
-      case "adult male":
-        return "Adult";
+      case 'adult':
+      case 'adults':
+      case 'adult female':
+      case 'adult male':
+        return 'Adult';
 
-      case "larva":
-        return "Larval";
+      case 'larva':
+        return 'Larval';
 
-      case "not recorded":
-        return "Not recorded";
+      case 'not recorded':
+        return 'Not recorded';
 
-      case "pre-adult":
-        return "Subadult";
+      case 'pre-adult':
+        return 'Subadult';
 
-      case "In flower":
-        return "Flowering";
+      case 'In flower':
+        return 'Flowering';
 
       default:
         return $stage;
@@ -2016,11 +2014,11 @@ class Rest_Controller extends Controller {
     }
     $field = $params[0];
     switch($field) {
-      case "_id":
+      case '_id':
         return preg_replace('/^brc1\|/', 'iBRC', $doc['_id']);
 
-      case "location.input_sref_system":
-      case "location.output_sref_system":
+      case 'location.input_sref_system':
+      case 'location.output_sref_system':
         $value = strval($this->getRawEsFieldValue($doc, $field));
         if ($value === '4326') {
           return 'WGS84';
@@ -2032,7 +2030,7 @@ class Rest_Controller extends Controller {
           return strtoupper($value);
         }
 
-      case "datasource_code":
+      case 'datasource_code':
         $w = $doc['metadata']['website']['title'];
         $s = $doc['metadata']['survey']['title'];
         if (isset($doc['metadata']['group'])) {
@@ -2043,7 +2041,7 @@ class Rest_Controller extends Controller {
           return "$w | $s";
         }
 
-      case "identification.verification_status":
+      case 'identification.verification_status':
         $value = $this->getRawEsFieldValue($doc, $field);
         if($value === 'V'){
           return 'Accepted';
@@ -2067,7 +2065,7 @@ class Rest_Controller extends Controller {
           return $value;
         }
 
-      case "identification.verification_substatus":
+      case 'identification.verification_substatus':
         $status = $this->getRawEsFieldValue($doc, 'identification.verification_status');
         $value = strval($this->getRawEsFieldValue($doc, $field));
         if($status === 'V'){
@@ -2104,7 +2102,7 @@ class Rest_Controller extends Controller {
           return NULL;
         }
 
-      case "identification.query":
+      case 'identification.query':
         $value = $this->getRawEsFieldValue($doc, $field);
         if($value === 'A'){
           return 'Answered';
@@ -2135,7 +2133,7 @@ class Rest_Controller extends Controller {
    *   A quantity formatted/filtered as indicated by passed parameter.
    */
   private function esGetSpecialFieldOrganismQuantity(array $doc, array $params) {
-    $format = !empty($params) ? $params[0] : "";
+    $format = !empty($params) ? $params[0] : '';
     $quantity = !empty($doc['occurrence']['organism_quantity']) ? $doc['occurrence']['organism_quantity'] : '';
     if (!empty($doc['occurrence']['zero_abundance']) && $doc['occurrence']['zero_abundance'] !== 'false') {
       $zero = True;
@@ -2144,7 +2142,7 @@ class Rest_Controller extends Controller {
       $zero = False;
     }
     switch($format) {
-      case "mapmate":
+      case 'mapmate':
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.
@@ -2158,7 +2156,7 @@ class Rest_Controller extends Controller {
           return '';
         }
 
-      case "integer":
+      case 'integer':
         // Only return the value if it is an iteger.
         if(preg_match('/^\d+$/', $quantity)) {
           return $quantity;
@@ -2167,7 +2165,7 @@ class Rest_Controller extends Controller {
           return '';
         }
 
-      case "non-integer":
+      case 'non-integer':
         // Only return the value if it is not an iteger.
         if(!preg_match('/^\d+$/', $quantity)) {
           return $quantity;
@@ -2197,12 +2195,12 @@ class Rest_Controller extends Controller {
       return 'n/a';
     }
     $coords = explode(',', $root['point']);
-    $format = !empty($params) ? $params[0] : "";
+    $format = !empty($params) ? $params[0] : '';
     switch($format) {
-      case "decimal":
+      case 'decimal':
         return $coords[0];
 
-      case "nssuffix": // Implemented as the default.
+      case 'nssuffix': // Implemented as the default.
       default:
         $ns = $coords[0] >= 0 ? 'N' : 'S';
         $lat = number_format(abs($coords[0]), 3);

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -2353,6 +2353,10 @@ class Rest_Controller extends Controller {
       $fn = 'esGetSpecialField' .
         str_replace('_', '', ucwords($matches['sourceType']));
       $params = empty($matches['params']) ? [] : explode(':', $matches['params']);
+      if (count($params) > 0 && strpos($params[0], '_') === 0) {
+        // Resets docsource to root if first param (field) startus with '_'.
+        $docSource = $doc;
+      }
       if (method_exists($this, $fn)) {
         $row[] = $this->$fn($docSource, $params);
       }

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1582,7 +1582,7 @@ class Rest_Controller extends Controller {
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
     $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
-    return  DateTime::format($params[1], $dt);
+    return  $dt.format($params[1]);
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1776,14 +1776,14 @@ class Rest_Controller extends Controller {
    */
   private function esGetSpecialFieldOrganismQuantity(array $doc, array $params) {
     $format = !empty($params) ? $params[0] : "";
-    $zero = isset($doc['occurrence']['zero_abundance']) ? $doc['occurrence']['zero_abundance'] : 'false';
+    $zero = isset($doc['occurrence']['zero_abundance']) ? $doc['occurrence']['zero_abundance'] : false;
     $quantity = isset($doc['occurrence']['organism_quantity']) ? $doc['occurrence']['organism_quantity'] : '';
     switch($format) {
       case "mapmate":
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.
-        if ($zero === 'true' || $quantity === '0') {
+        if ($zero || $quantity === '0') {
           return -7;
         }
         elseif(preg_match('/^\d+$/', $quantity)) {

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1784,6 +1784,7 @@ class Rest_Controller extends Controller {
     }
     switch($format) {
       case "mapmate":
+        return $zero;
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1582,7 +1582,8 @@ class Rest_Controller extends Controller {
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
     $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
-    return  $dt->format($params[1]);
+    // $dt->format($params[1]);
+    return  "$dtvalue # $params[1]";
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1582,7 +1582,7 @@ class Rest_Controller extends Controller {
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
     $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
-    return  $dt.format($params[1]);
+    return  $dt->format($params[1]);
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1008,9 +1008,9 @@ class Rest_Controller extends Controller {
     ],
     "easy-download" => [
       ['caption' => 'ID', 'field' => 'id'],
-      ['caption' => 'RecordKey', 'field' => '#id:easy#'],
+      ['caption' => 'RecordKey', 'field' => '_id'],
       ['caption' => 'External key', 'field' => 'occurrence_external_key'],
-      ['caption' => 'Source', 'field' => '#datasource_code:with_group#'],
+      ['caption' => 'Source', 'field' => '#datasource_code:<wt> | <st> {|} <gt>#'],
       ['caption' => 'Species', 'field' => 'taxon.accepted_name'],
       ['caption' => 'Common name', 'field' => 'taxon.vernacular_name'],
       ['caption' => 'Taxon group', 'field' => 'taxon.group'],
@@ -1046,9 +1046,9 @@ class Rest_Controller extends Controller {
       ['caption' => 'Images', 'field' => '#occurrence_media#'],
       ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H\:i#'],
       ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y H\:i#'],
-      ['caption' => 'Verification status 1', 'field' => '#verification_status:standard#'],
-      ['caption' => 'Verification status 2', 'field' => '#verification_substatus:standard#'],
-      ['caption' => 'Query', 'field' => '#query:standard#'],
+      ['caption' => 'Verification status 1', 'field' => '#verification_status:astext#'],
+      ['caption' => 'Verification status 2', 'field' => '#verification_substatus:astext#'],
+      ['caption' => 'Query', 'field' => '#query:astext#'],
       ['caption' => 'Verifier', 'field' => 'identification.verifier.name'],
       ['caption' => 'Verified on', 'field' => '#datetime:identification.verified_on:d/m/Y H\:i#'],
       ['caption' => 'Licence', 'field' => 'metadata.licence_code'],
@@ -1058,10 +1058,10 @@ class Rest_Controller extends Controller {
       ['caption' => 'Taxon', 'field' => 'taxon.accepted_name'],
       ['caption' => 'Site', 'field' => 'location.verbatim_locality'],
       ['caption' => 'Gridref', 'field' => 'location.output_sref'],
-      ['caption' => 'VC', 'field' => '#vc:mapmate#'],
+      ['caption' => 'VC', 'field' => '#higher_geography:Vice County:code:mapmate#'],
       ['caption' => 'Recorder', 'field' => 'event.recorded_by'],
       ['caption' => 'Determiner', 'field' => 'identification.identified_by'],
-      ['caption' => 'Date', 'field' => '#record_date:mapmate#'],
+      ['caption' => 'Date', 'field' => '#event_date:mapmate#'],
       ['caption' => 'Quantity', 'field' => '#organism_quantity:mapmate#'],
       ['caption' => 'Method', 'field' => 'event.sampling_protocol'],
       ['caption' => 'Sex', 'field' => '#sex:mapmate#'],
@@ -1070,13 +1070,13 @@ class Rest_Controller extends Controller {
       ['caption' => 'Comment', 'field' => '#sample_occurrence_comment#'],
       ['caption' => 'ID', 'field' => 'id'],
       ['caption' => 'RecordKey', 'field' => '_id'],
-      ['caption' => 'NonNumericQuantity', 'field' => '#organism_quantity:non-integer#'],
+      ['caption' => 'NonNumericQuantity', 'field' => '#organism_quantity:exclude_integer#'],
       ['caption' => 'Habitat', 'field' => 'event.habitat'],
       ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H\:i\:s#'],
       ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G\:i\:s#'],
-      ['caption' => 'Verification status 1', 'field' => '#verification_status:standard#'],
-      ['caption' => 'Verification status 2', 'field' => '#verification_substatus:standard#'],
-      ['caption' => 'Query', 'field' => '#query:standard#'],
+      ['caption' => 'Verification status 1', 'field' => '#verification_status:astext#'],
+      ['caption' => 'Verification status 2', 'field' => '#verification_substatus:astext#'],
+      ['caption' => 'Query', 'field' => '#query:astext#'],
       ['caption' => 'Licence', 'field' => 'metadata.licence_code'],
     ]
   ];
@@ -1155,16 +1155,12 @@ class Rest_Controller extends Controller {
         elseif ($field === '#data_cleaner_icons#') {
           $fields[] = 'identification.auto_checks';
         }
-        elseif (preg_match('/^#datasource_code(:.+)*#$/', $field)) {
+        elseif (preg_match('/^#datasource_code(.*)#$/', $field)) {
           $fields[] = 'metadata.website';
           $fields[] = 'metadata.survey';
           $fields[] = 'metadata.group';
         }
-        elseif ($field === '#event_date#') {
-          $fields[] = 'event.date_start';
-          $fields[] = 'event.date_end';
-        }
-        elseif (preg_match('/^#record_date(.*)#$/', $field)) {
+        elseif (preg_match('/^#event_date(.*)#$/', $field)) {
           $fields[] = 'event.date_start';
           $fields[] = 'event.date_end';
         }
@@ -1742,7 +1738,7 @@ class Rest_Controller extends Controller {
       return 'Incorrect params for verification status field';
     }
     $value = $this->getRawEsFieldValue($doc, 'identification.verification_status');
-    if ($params[0] === 'standard') {
+    if ($params[0] === 'astext') {
       // Provides backward compatibility with pre-ES downloads.
       if($value === 'V'){
         return 'Accepted';
@@ -1790,7 +1786,7 @@ class Rest_Controller extends Controller {
     }
     $status = $this->getRawEsFieldValue($doc, 'identification.verification_status');
     $value = $this->getRawEsFieldValue($doc, 'identification.verification_substatus');
-    if ($params[0] === 'standard') {
+    if ($params[0] === 'astext') {
       // Provides backward compatibility with pre-ES downloads.
       if($status === 'V'){
         if ($value === '1') {
@@ -1849,7 +1845,7 @@ class Rest_Controller extends Controller {
       return 'Incorrect params for query field';
     }
     $value = $this->getRawEsFieldValue($doc, 'identification.query');
-    if ($params[0] === 'standard') {
+    if ($params[0] === 'astext') {
       // Provides backward compatibility with pre-ES downloads.
       if($value === 'A'){
         return 'Answered';
@@ -1965,24 +1961,31 @@ class Rest_Controller extends Controller {
    */
   private function esGetSpecialFieldDatasourceCode(array $doc, $params) {
     if (count($params) > 1) {
-      return 'Incorrect params for non-standard datasource field (must be 0 or 1)';
+      return 'Incorrect params for datasource code field (must be 0 or 1)';
     }
     $w = $doc['metadata']['website'];
     $s = $doc['metadata']['survey'];
-    if (count($params) && $params[0] === 'with_group') {
-      // Provides backward compatibility with pre-ES downloads.
-      if (isset($doc['metadata']['group'])) {
-        $g = $doc['metadata']['group'];
-        return "$w[title] | $s[title] | $g[title]";
-      }
-      else {
-        return "$w[title] | $s[title]";
-      }
+    if (isset($doc['metadata']['group'])) {
+      $g = $doc['metadata']['group'];
     }
     else {
-      // Default format uses id and title for both website and dataset.
-      return "$w[id] ($w[title]) | $s[id] ($s[title])";
+      $g = array('title' => '', 'id' => '');
     }
+    if (count($params)) {
+      $pattern = $params[0];
+    }
+    else {
+      $pattern = '<wi> (<wt>) | <si> (<st>)';
+    }
+    $regpatterns = array('/<wi>/', '/<wt>/', '/<si>/' , '/<st>/', '/<gi>/', '/<gt>/');
+    $replacements = array($w['id'], $w['title'], $s['id'], $s['title'], $g['id'] , $g['title']);
+    $output = preg_replace($regpatterns, $replacements, $pattern);
+    // Disregarding whitespace, if the output string ends in something in curly braces,
+    // then remove it. Allows us to conditionally remove a separator if there's no group.
+    $output = preg_replace('/\s*{.*}\s*$/', '', $output);
+    // Remvove curly braces from output.
+    $output = preg_replace('/({|})/', '', $output);
+    return $output;
   }
 
   /**
@@ -1994,11 +1997,23 @@ class Rest_Controller extends Controller {
    *
    * @param array $doc
    *   Elasticsearch document.
+   * @param array $params
+   *   Provided parameters in field definition.
+   *   Can be empty or a string to specify a format.
    *
    * @return string
    *   Formatted readable date.
    */
-  private function esGetSpecialFieldEventDate(array $doc) {
+  private function esGetSpecialFieldEventDate(array $doc, array $params) {
+    if (count($params) > 1) {
+      return 'Incorrect params for formatted date (must be zero or one)';
+    }
+    if (count($params)) {
+      $format = $params[0];
+    } 
+    else {
+      $format = "";
+    }
     // Check in case fields are in composite agg key.
     $root = isset($doc['key']) ? $doc['key'] : $doc['event'];
     $start = isset($root['date_start']) ? $root['date_start'] :
@@ -2011,65 +2026,46 @@ class Rest_Controller extends Controller {
     if (preg_match('/^\-?\d+$/', $end)) {
       $end = date('d/m/Y', $end / 1000);
     }
+    if (preg_match('/^(\d\d\d\d)-(\d\d)-(\d\d)$/', $start, $matches)) {
+      $start = $matches[3] . '/' . $matches[2] . '/' . $matches[1];
+    }
+    if (preg_match('/^(\d\d\d\d)-(\d\d)-(\d\d)$/', $end, $matches)) {
+      $end = $matches[3] . '/' . $matches[2] . '/' . $matches[1];
+    }
     if (empty($start) && empty($end)) {
-      return 'Unknown';
+      if ($format === 'mapmate') {
+        return '';
+      } else {
+        return 'Unknown';
+      }
     }
     elseif (empty($end)) {
-      return "After $start";
+      if ($format === 'mapmate') {
+        // Mapmate can't deal with unbound ranges
+        // - replace with date of known bound.
+        return $start;
+      } else {
+        return "After $start";
+      }
     }
     elseif (empty($start)) {
-      return "Before $end";
+      if ($format === 'mapmate') {
+        // Mapmate can't deal with unbound ranges
+        // - replace with date of known bound.
+        return $end;
+      } else {
+        return "Before $end";
+      }
     }
     elseif ($start === $end) {
       return $start;
     }
     else {
-      return "$start to $end";
-    }
-  }
-
-
-  /**
-   * Special field handler for Elasticsearch event dates with format options.
-   *
-   * Converts event.date_from and/or event.date_to to a date string
-   * with the identified format.
-   * 
-   * @param array $doc
-   *   Elasticsearch document.
-   * @param array $params
-   *   An identifier for the format.
-   *
-   * @return string
-   *   Formatted date.
-   */
-  private function esGetSpecialFieldRecordDate(array $doc, array $params) {
-    if (count($params) !== 1) {
-      return 'Incorrect params for formatted date';
-    }
-    $date = $this->esGetSpecialFieldEventDate($doc);
-    if ($params[0] === 'mapmate') {
-      // Provides compatibility for import to MapMate.
-      if (substr($date,0,7) === 'Before ') {
-        // Mapmate can't deal with unbound ranges
-        // - replace with date of known bound.
-        return substr($date, 7);
-      } 
-      elseif (substr($date,0,6) === 'After ') {
-        // Mapmate can't deal with unbound ranges
-        // - replace with date of known bound.
-        return substr($date, 6);
+      if ($format === 'mapmate') {
+        return $start . '-' . $end;
+      } else {
+        return "$start to $end";
       }
-      elseif (strpos($date, ' to ') !== false) {
-        // Mapmate uses a hyphen in date ranges.
-        return str_replace(' to ','-',$date);
-      }
-      else {
-        return $date;
-      }
-    }
-    else {
-      return $date;
     }
   }
 
@@ -2080,7 +2076,7 @@ class Rest_Controller extends Controller {
    * output. Configurable output by passing parameters:
    * * type - limit output to this type.
    * * field - limit output to content of this field (name, id, type or code).
-   * * text - set to true to convert the resultant JSON to text.
+   * * format - can be left empty or set to either json or mapmate.
    * E.g. pass type=Country, field=name, text=true to convert to a plaintext
    * Country name.
    *
@@ -2118,50 +2114,26 @@ class Rest_Controller extends Controller {
         foreach ($r as $outputItem) {
           $outputList[] = is_array($outputItem) ? implode('; ', $outputItem) : $outputItem;
         }
-        return implode(' | ', $outputList);
+        if (isset($params[2]) && $params[2] === 'mapmate') {
+          if (count($outputList) === 1) {
+            return $outputList[0];
+          }
+          else {
+            return 0;
+          }
+        }
+        else {
+          return implode(' | ', $outputList);
+        }
       }
     }
     else {
-      return '';
-    }
-  }
-
-  /**
-   * Special field handler for Elasticsearch location VC with format options.
-   *
-   * Converts Vice County code to values as specified in format option.
-   * 
-   * @param array $doc
-   *   Elasticsearch document.
-   * @param array $params
-   *   An identifier for the format.
-   *
-   * @return string
-   *   Formatted VC.
-   */
-  private function esGetSpecialFieldVc(array $doc, array $params) {
-    if (count($params) !== 1) {
-      return 'Incorrect params for formatted VC';
-    }
-    $vcnum = $this->esGetSpecialFieldHigherGeography($doc, array('Vice County', 'code'));
-    if ($params[0] === 'mapmate') {
-      // Provides compatibility for import to MapMate
-      if ($vcnum === '') {
-        // Where unable to assign VC, return 0. This will 
-        // cause MapMate to work out the VC itself.
-        return '0';
-      } 
-      elseif(strpos($vcnum, '|') > 0) {
-        // More than one VC returned, set to zer to let
-        // MapMate decide where to place the record.
-        return '0';
+      if (isset($params[2]) && $params[2] === 'mapmate') {
+        return 0;
       }
       else {
-        return $vcnum;
+        return '';
       }
-    }
-    else {
-      return vcnum;
     }
   }
 
@@ -2299,7 +2271,7 @@ class Rest_Controller extends Controller {
         }
 
       case 'integer':
-        // Only return the value if it is an iteger.
+        // Only return the value if it is an integer.
         if(preg_match('/^\d+$/', $quantity)) {
           return $quantity;
         }
@@ -2307,8 +2279,8 @@ class Rest_Controller extends Controller {
           return '';
         }
 
-      case 'non-integer':
-        // Only return the value if it is not an iteger.
+      case 'exclude_integer':
+        // Only return the value if it is not an integer.
         if(!preg_match('/^\d+$/', $quantity)) {
           return $quantity;
         }

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1010,8 +1010,8 @@ class Rest_Controller extends Controller {
       ['caption' => 'RecordKey', 'field' => '_id'],
       ['caption' => 'NonNumericQuantity', 'field' => '#organism_quantity:non-integer#'],
       ['caption' => 'Habitat', 'field' => 'event.habitat'],
-      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G:i:s#'],
-      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G:i:s#'],
+      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G-i-s#'],
+      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G-i-s#'],
       ['caption' => 'Verification status 1', 'field' => 'identification.verification_status'],
       ['caption' => 'Verification status 2', 'field' => '#null_if_zero:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => 'identification.query'],
@@ -1146,7 +1146,7 @@ class Rest_Controller extends Controller {
         elseif (preg_match('/^#null_if_zero:([a-z_]+(\.[a-z_]+)*)#$/', $field, $matches)) {
           $fields[] = $matches[1];
         }
-        elseif (preg_match('/^#datetime:([a-z_]+(\.[a-z_]+)*)#$/', $field, $matches)) {
+        elseif (preg_match('/^#datetime:([a-z_]+(\.[a-z_]+)*):.*#$/', $field, $matches)) {
           $fields[] = $matches[1];
         }
       }

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1010,8 +1010,8 @@ class Rest_Controller extends Controller {
       ['caption' => 'RecordKey', 'field' => '_id'],
       ['caption' => 'NonNumericQuantity', 'field' => '#organism_quantity:non-integer#'],
       ['caption' => 'Habitat', 'field' => 'event.habitat'],
-      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G-i-s#'],
-      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G-i-s#'],
+      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H^i^s#'], // Can't use : in format spec here - use ^ instead which is translated to :
+      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G^i^s#'], // Can't use : in format spec here - use ^ instead which is translated to :
       ['caption' => 'Verification status 1', 'field' => 'identification.verification_status'],
       ['caption' => 'Verification status 2', 'field' => '#null_if_zero:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => 'identification.query'],
@@ -1582,10 +1582,12 @@ class Rest_Controller extends Controller {
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
     $dt = DateTime::createFromFormat("Y-m-d G:i:s.u", $dtvalue);
+    // Replace any ^ characters in format with :
+    $format = str_replace("^", ":", $params[1]);
     if ($dt === FALSE) {
       return  $dtvalue;
     } else {
-      return $dt->format($params[1]);
+      return $dt->format($format);
     }
   }
 

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1581,9 +1581,12 @@ class Rest_Controller extends Controller {
       return 'Incorrect params for Datetime field';
     }
     $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
-    $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
-    // $dt->format($params[1]);
-    return  "$dtvalue # $params[1]";
+    $dt = DateTime::createFromFormat("Y-m-d G:i:s.u", $dtvalue);
+    if ($dt === FALSE) {
+      return  $dtvalue;
+    } else {
+      return $dt->format($params[1]);
+    }
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1010,8 +1010,8 @@ class Rest_Controller extends Controller {
       ['caption' => 'RecordKey', 'field' => '_id'],
       ['caption' => 'NonNumericQuantity', 'field' => '#organism_quantity:non-integer#'],
       ['caption' => 'Habitat', 'field' => 'event.habitat'],
-      // ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G:i:s#'],
-      // ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G:i:s#'],
+      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y G:i:s#'],
+      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G:i:s#'],
       ['caption' => 'Verification status 1', 'field' => 'identification.verification_status'],
       ['caption' => 'Verification status 2', 'field' => '#null_if_zero:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => 'identification.query'],
@@ -1559,6 +1559,30 @@ class Rest_Controller extends Controller {
     else {
       return '';
     }
+  }
+
+  /**
+   * Special field handler ES datetime fields to output with provided format.
+   *
+   * Return the datetime as a string formatted as specified.
+   *
+   * @param array $doc
+   *   Elasticsearch document.
+   * @param array $params
+   *   Provided parameters: 
+   *   1. ES field
+   *   2. datetime format
+   *
+   * @return string
+   *   Formatted string
+   */
+  private function esGetSpecialFieldDatetime(array $doc, array $params) {
+    if (count($params) !== 2) {
+      return 'Incorrect params for Datetime field';
+    }
+    $dtvalue = $this->getRawEsFieldValue($doc, $params[0]);
+    $dt = DateTime::createFromFormat("M dS Y, G:i:s.u", $dtvalue);
+    return  DateTime::format($params[1], $dt);
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1652,7 +1652,7 @@ class Rest_Controller extends Controller {
     // No need to duplicate work of esGetSpecialFieldEventDate.
     // Use that function to format the date initially then
     // modify for MapMate.
-    $date = esGetSpecialFieldEventDate($doc);
+    $date = $this->esGetSpecialFieldEventDate($doc);
     if (startsWith($date, "Before ")) {
       // Mapmate can't deal with unbound ranges
       // - replace with date of known bound.

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1785,7 +1785,7 @@ class Rest_Controller extends Controller {
     }
     switch($format) {
       case "mapmate":
-        return $zero ? "zero" : "not zero";
+        return $doc['occurrence']['zero_abundance'];
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1779,12 +1779,13 @@ class Rest_Controller extends Controller {
     $quantity = !empty($doc['occurrence']['organism_quantity']) ? $doc['occurrence']['organism_quantity'] : '';
     if (!empty($doc['occurrence']['zero_abundance']) && $doc['occurrence']['zero_abundance'] !== 'false') {
       $zero = True;
-    } else {
+    } 
+    else {
       $zero = False;
     }
     switch($format) {
       case "mapmate":
-        return $zero;
+        return $zero ? "zero" : "not zero";
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1519,7 +1519,7 @@ class Rest_Controller extends Controller {
     };
   }
 
-   /**
+  /**
    * Special field handler returns an empty string. This is useful
    * where the output CSV must contain a column to which no
    * useful data can be mapped.
@@ -1534,7 +1534,7 @@ class Rest_Controller extends Controller {
     return '';
   }
 
-   /**
+  /**
    * Special field handler for Elasticsearch to combine
    * the sample and occurrence comment.
    *
@@ -1736,7 +1736,7 @@ class Rest_Controller extends Controller {
     }
   }
 
-   /**
+  /**
    * Special field handler for Elasticsearch event dates compatible for MapMate.
    *
    * Converts event.date_from and event.date_to to a readable date string, e.g.
@@ -1844,7 +1844,7 @@ class Rest_Controller extends Controller {
     $vc = $this->esGetSpecialFieldHigherGeography($doc, array("Vice County", "code"));
     if ($vc === "") {
       // Where unable to assign VC, return 0. This will 
-      // cause MapMate to work out the VC itself..
+      // cause MapMate to work out the VC itself.
       return "0";
     } 
     else {
@@ -1852,7 +1852,7 @@ class Rest_Controller extends Controller {
     }
   }
 
- /**
+  /**
    * Special field handler for Elasticsearch sex formatted for MapMate.
    *
    * Converts occurrence.sex to values acceptable for
@@ -1885,7 +1885,7 @@ class Rest_Controller extends Controller {
     }
   }
 
- /**
+  /**
    * Special field handler for Elasticsearch life_stage formatted for MapMate.
    *
    * Converts occurrence.life_stage to values acceptable for

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1663,7 +1663,7 @@ class Rest_Controller extends Controller {
       // - replace with date of known bound.
       return substr($date, 6);
     }
-    elseif (strpos($a, ' to ') !== false) {
+    elseif (strpos($date, ' to ') !== false) {
       // Mapmate uses a hyphen in date ranges.
       return str_replace(" to ","-",$date);
     }

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1653,12 +1653,12 @@ class Rest_Controller extends Controller {
     // Use that function to format the date initially then
     // modify for MapMate.
     $date = $this->esGetSpecialFieldEventDate($doc);
-    if (startsWith($date, "Before ")) {
+    if (substr($date,0,7) === "Before ") {
       // Mapmate can't deal with unbound ranges
       // - replace with date of known bound.
       return substr($date, 7);
     } 
-    elseif (startsWith($date, "After ")) {
+    elseif (substr($date,0,6) === "After ") {
       // Mapmate can't deal with unbound ranges
       // - replace with date of known bound.
       return substr($date, 6);

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1941,17 +1941,22 @@ class Rest_Controller extends Controller {
     switch($sex) {
       case "female":
         return "f";
+
       case "male":
         return "m";
+
       case "mixed":
         return "g";
+
       case "queen":
         return "q";
+
       case "not recorded":
       case "not known":
       case "unknown":
       case "unsexed:":
         return "u";
+
       default:
         return $sex;
     }
@@ -1977,14 +1982,19 @@ class Rest_Controller extends Controller {
       case "adult female":
       case "adult male":
         return "Adult";
+
       case "larva":
         return "Larval";
+
       case "not recorded":
         return "Not recorded";
+
       case "pre-adult":
         return "Subadult";
+
       case "In flower":
         return "Flowering";
+
       default:
         return $stage;
     }
@@ -2008,6 +2018,7 @@ class Rest_Controller extends Controller {
     switch($field) {
       case "_id":
         return preg_replace('/^brc1\|/', 'iBRC', $doc['_id']);
+
       case "location.input_sref_system":
       case "location.output_sref_system":
         $value = strval($this->getRawEsFieldValue($doc, $field));
@@ -2020,6 +2031,7 @@ class Rest_Controller extends Controller {
         else {
           return strtoupper($value);
         }
+
       case "datasource_code":
         $w = $doc['metadata']['website']['title'];
         $s = $doc['metadata']['survey']['title'];
@@ -2030,6 +2042,7 @@ class Rest_Controller extends Controller {
         else {
           return "$w | $s";
         }
+
       case "identification.verification_status":
         $value = $this->getRawEsFieldValue($doc, $field);
         if($value === 'V'){
@@ -2053,6 +2066,7 @@ class Rest_Controller extends Controller {
         else {
           return $value;
         }
+
       case "identification.verification_substatus":
         $status = $this->getRawEsFieldValue($doc, 'identification.verification_status');
         $value = strval($this->getRawEsFieldValue($doc, $field));
@@ -2089,6 +2103,7 @@ class Rest_Controller extends Controller {
         else {
           return NULL;
         }
+
       case "identification.query":
         $value = $this->getRawEsFieldValue($doc, $field);
         if($value === 'A'){
@@ -2100,6 +2115,7 @@ class Rest_Controller extends Controller {
         else {
           return $value;
         }
+
       default:
         return 'No backward compatibility for ' . $field;
     }
@@ -2141,6 +2157,7 @@ class Rest_Controller extends Controller {
         else {
           return '';
         }
+
       case "integer":
         // Only return the value if it is an iteger.
         if(preg_match('/^\d+$/', $quantity)) {
@@ -2149,6 +2166,7 @@ class Rest_Controller extends Controller {
         else {
           return '';
         }
+
       case "non-integer":
         // Only return the value if it is not an iteger.
         if(!preg_match('/^\d+$/', $quantity)) {
@@ -2157,6 +2175,7 @@ class Rest_Controller extends Controller {
         else {
           return '';
         }
+
       default:
         return $quantity;
     }
@@ -2182,8 +2201,8 @@ class Rest_Controller extends Controller {
     switch($format) {
       case "decimal":
         return $coords[0];
-      case "nssuffix":
-        // Implemented as the default.
+
+      case "nssuffix": // Implemented as the default.
       default:
         $ns = $coords[0] >= 0 ? 'N' : 'S';
         $lat = number_format(abs($coords[0]), 3);
@@ -2234,8 +2253,8 @@ class Rest_Controller extends Controller {
     switch($format) {
       case "decimal":
         return $coords[1];
-      case "ewsuffix":
-        // Implemented as the default.
+
+      case "ewsuffix": // Implemented as the default.
       default:
         $ew = $coords[1] >= 0 ? 'E' : 'W';
         $lon = number_format(abs($coords[1]), 3);

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1032,7 +1032,7 @@ class Rest_Controller extends Controller {
       ['caption' => 'Date interpreted', 'field' => '#event_date#'],
       ['caption' => 'Date from', 'field' => 'event.date_start'],
       ['caption' => 'Date to', 'field' => 'event.date_end'],
-      ['caption' => 'Date type', 'field' => ''], // Unavalable in ES index (date_type)
+      ['caption' => 'Date type', 'field' => 'event.date_type'], 
       ['caption' => 'Sample method', 'field' => 'event.sampling_protocol'],
       ['caption' => 'Recorder', 'field' => 'event.recorded_by'],
       ['caption' => 'Determiner', 'field' => 'identification.identified_by'],
@@ -1040,7 +1040,7 @@ class Rest_Controller extends Controller {
       ['caption' => 'Sex', 'field' => 'occurrence.sex'],
       ['caption' => 'Stage', 'field' => 'occurrence.life_stage'],
       ['caption' => 'Count of sex or stage', 'field' => 'occurrence.organism_quantity'],
-      ['caption' => 'Zero abundance', 'field' => 'occurrence.zero_abundance'], // Output in easy download was T/F - this will be true/false
+      ['caption' => 'Zero abundance', 'field' => 'occurrence.zero_abundance'], 
       ['caption' => 'Comment', 'field' => 'occurrence.occurrence_remarks'],
       ['caption' => 'Sample comment', 'field' => 'event.event_remarks'],
       ['caption' => 'Images', 'field' => '#occurrence_media#'],

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1046,7 +1046,7 @@ class Rest_Controller extends Controller {
       ['caption' => 'Images', 'field' => '#occurrence_media#'],
       ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H^i#'], // Can't use : in format spec here - use ^ instead which is translated to :
       ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y H^i#'], // Can't use : in format spec here - use ^ instead which is translated to :
-      ['caption' => 'Verification status 1', 'field' => '#backward:identification.verification_status#"'],
+      ['caption' => 'Verification status 1', 'field' => '#backward:identification.verification_status#'],
       ['caption' => 'Verification status 2', 'field' => '#backward:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => '#backward:identification.query#'],
       ['caption' => 'Verifier', 'field' => 'identification.verifier.name'],

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1044,13 +1044,13 @@ class Rest_Controller extends Controller {
       ['caption' => 'Comment', 'field' => 'occurrence.occurrence_remarks'],
       ['caption' => 'Sample comment', 'field' => 'event.event_remarks'],
       ['caption' => 'Images', 'field' => '#occurrence_media#'],
-      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H^i#'], // Can't use : in format spec here - use ^ instead which is translated to :
-      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y H^i#'], // Can't use : in format spec here - use ^ instead which is translated to :
+      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H\:i#'],
+      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y H\:i#'],
       ['caption' => 'Verification status 1', 'field' => '#backward:identification.verification_status#'],
       ['caption' => 'Verification status 2', 'field' => '#backward:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => '#backward:identification.query#'],
       ['caption' => 'Verifier', 'field' => 'identification.verifier.name'],
-      ['caption' => 'Verified on', 'field' => '#datetime:identification.verified_on:d/m/Y H^i#'], // Can't use : in format spec here - use ^ instead which is translated to :
+      ['caption' => 'Verified on', 'field' => '#datetime:identification.verified_on:d/m/Y H\:i#'],
       ['caption' => 'Licence', 'field' => 'metadata.licence_code'],
       ['caption' => 'Automated checks', 'field' => 'identification.auto_checks.result'], 
     ],
@@ -1072,8 +1072,8 @@ class Rest_Controller extends Controller {
       ['caption' => 'RecordKey', 'field' => '_id'],
       ['caption' => 'NonNumericQuantity', 'field' => '#organism_quantity:non-integer#'],
       ['caption' => 'Habitat', 'field' => 'event.habitat'],
-      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H^i^s#'], // Can't use : in format spec here - use ^ instead which is translated to :
-      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G^i^s#'], // Can't use : in format spec here - use ^ instead which is translated to :
+      ['caption' => 'Input on date', 'field' => '#datetime:metadata.created_on:d/m/Y H\:i\:s#'],
+      ['caption' => 'Last edited on date', 'field' => '#datetime:metadata.updated_on:d/m/Y G\:i\:s#'],
       ['caption' => 'Verification status 1', 'field' => 'identification.verification_status'],
       ['caption' => 'Verification status 2', 'field' => '#null_if_zero:identification.verification_substatus#'],
       ['caption' => 'Query', 'field' => 'identification.query'],
@@ -2441,7 +2441,14 @@ class Rest_Controller extends Controller {
     if (preg_match('/^#(?P<sourceType>[a-z_]*):?(?<params>.*)?#$/', $sourceField, $matches)) {
       $fn = 'esGetSpecialField' .
         str_replace('_', '', ucwords($matches['sourceType']));
-      $params = empty($matches['params']) ? [] : explode(':', $matches['params']);
+
+      // Split $matches['params'] into an array using colon as a separator.
+      // First replace escaped colons ('\:') with another marker ('EscapedColon')
+      // converting back to colons in the resulting array elements.
+      $params = empty($matches['params']) ? [] : explode(':', str_replace('\:', 'EscapedColon', $matches['params']));
+      foreach ($params as &$param) {
+        $param = str_replace('EscapedColon', ':', $param);
+      }
       if (count($params) > 0 && strpos($params[0], '_') === 0) {
         // Resets docSource to root if first param (field) startus with '_'.
         $docSource = $doc;

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1797,6 +1797,14 @@ class Rest_Controller extends Controller {
         else {
           return '';
         }
+      case "integer":
+        // Only return the value if it is an iteger.
+        if(preg_match('/^\d+$/', $quantity)) {
+          return $quantity;
+        }
+        else {
+          return '';
+        }
       case "non-integer":
         // Only return the value if it is not an iteger.
         if(!preg_match('/^\d+$/', $quantity)) {

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -1785,7 +1785,6 @@ class Rest_Controller extends Controller {
     }
     switch($format) {
       case "mapmate":
-        return $doc['occurrence']['zero_abundance'];
         // Mapmate will only accept integer values and uses a value 
         // of -7 to indicate a negative record. MapMate interprets
         // a quantity of 0 to mean 'present'.


### PR DESCRIPTION
@johnvanbreda - the title of the branchis a bit of a misnomer - this now is dealing with MapMate and changes to the Backward-compatibility formatting.

I've handled the MapMate special fields, and those needed for Backward compatibility a bit differently. In general, I've used separate special fields for MapMate but for the Backward compatibility, I've dealt with them altogether in a single '#backward:<field># field handler. If you've a strong preference about using one or the other way and want me to modify, let me know.

I've also run into a problem which I've spent several hours investigating but not resolved yet - you may be able to save me some time. If I download a large 'backward-compatible' file over 5000 records, the first 5000 records in the correct format, but the rest in the default download format. Somehow I need to preserve the user's download format choice across paging. Is the $fie object the place to do that or is there a better way?