### PR TITLE
Hotfix verification rules

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -29,14 +29,14 @@ defined('SYSPATH') or die('No direct script access.');
  *
  * @var string
  */
-$config['version'] = '6.2.5';
+$config['version'] = '6.2.6';
 
 /**
  * Version release date.
  *
  * @var string
  */
-$config['release_date'] = '2021-08-17';
+$config['release_date'] = '2021-08-19';
 
 /**
  * Link to the code repository downloads page.

--- a/modules/data_cleaner/helpers/data_cleaner.php
+++ b/modules/data_cleaner/helpers/data_cleaner.php
@@ -141,6 +141,7 @@ class data_cleaner {
         continue;
       }
       if (preg_match('/^\[(?P<section>.+)\]$/', $line, $matches)) {
+        // Found a [Section] heading.
         if (!empty($currentSectionData)) {
           $r[$currentSection] = $currentSectionData;
         }
@@ -150,12 +151,19 @@ class data_cleaner {
         $dataGroup = 0;
       }
       elseif (preg_match('/^([^=\r\n]+)=([^\r\n]*)$/', $line, $matches)) {
+        // Found a key=value.
         self::addDataValue($currentSection, $currentSectionData, $dataGroup, $matches[1], $matches[2]);
       }
+      elseif (preg_match('/^(?P<key>[^,\r\n]+),(?P<value>[^\r\n]*)$/', $line, $matches)) {
+        // Found a key,value as used in ancillary species data.
+        self::addDataValue($currentSection, $currentSectionData, $dataGroup, $matches['key'], $matches['value']);
+      }
       elseif (preg_match('/^(?P<key>.+)$/', $line, $matches)) {
+        // Found a key with no value.
         self::addDataValue($currentSection, $currentSectionData, $dataGroup, $matches['key'], '-');
       }
       elseif (empty($line) && $currentSection !== 'metadata') {
+        // Found a blank line indicating end of a data group.
         $dataGroup++;
       }
     }

--- a/modules/data_cleaner/tests/helpers/data_cleanerTest.php
+++ b/modules/data_cleaner/tests/helpers/data_cleanerTest.php
@@ -1,0 +1,186 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit test class for verification rule module.
+ */
+class VerificationRuleTest extends TestCase {
+
+  /**
+   * Ensure id difficulty test file is parsed correctly.
+   */
+  public function test_parser_identification_difficulty() {
+    $file = 'modules/data_cleaner/tests/rule_files/id_difficulty.txt';
+    $filecontent = file_get_contents($file);
+    $parsed = data_cleaner::parseTestFile($filecontent);
+    $expected = [
+      'metadata' => [
+        'testtype' => 'IdentificationDifficulty',
+        'organisation' => 'Identification difficulty organisation',
+        'lastchanged' => '20210816',
+      ],
+      'ini' => [
+        '0' => [
+          '1' => 'Identification difficulty message 1.',
+          '2' => 'Identification difficulty message 2, with comma.',
+        ],
+      ],
+      'data' => [
+        '0' => [
+          'nbnsys0000007825' => '1',
+          'nbnsys0000007826' => '2',
+        ],
+      ],
+    ];
+    $this->assertEquals($expected, $parsed);
+  }
+
+  /**
+   * Ensure ancillary species test file is parsed correctly.
+   */
+  public function test_parse_ancillary_species() {
+    $file = 'modules/data_cleaner/tests/rule_files/ancillary_species.txt';
+    $filecontent = file_get_contents($file);
+    $parsed = data_cleaner::parseTestFile($filecontent);
+    $expected = [
+      'metadata' => [
+        'testtype' => 'AncillarySpecies',
+        'group' => 'Ancillary species rule group',
+        'shortname' => 'Ancillary species rule name',
+        'description' => 'Ancillary species rule description',
+        'errormsg' => 'Ancillary species error message',
+        'reverserule' => 'True',
+        'lastchanged' => '20210816',
+      ],
+      'ini' => [
+        '0' => [
+          '1' => 'Ancillary species message 1.',
+          '2' => 'Ancillary species message 2, with comma.',
+        ],
+      ],
+      'data' => [
+        '0' => [
+          'nbnsys0000007848' => '1',
+          'nbnsys0100004993' => '2',
+        ],
+      ],
+    ];
+    $this->assertEquals($expected, $parsed);
+  }
+
+  /**
+   * Ensure period test file is parsed correctly.
+   */
+  public function test_parse_period() {
+    $file = 'modules/data_cleaner/tests/rule_files/period.txt';
+    $filecontent = file_get_contents($file);
+    $parsed = data_cleaner::parseTestFile($filecontent);
+    $expected = [
+      'metadata' => [
+        'testtype' => 'Period',
+        'group' => 'Period rule group',
+        'shortname' => 'Period rule name',
+        'description' => 'Period rule description',
+        'errormsg' => 'Period rule error message',
+        'tvk' => 'NBNSYS0100005964',
+        'startdate' => '',
+        'enddate' => '19581231',
+        'lastchanged' => '20210816',
+      ],
+    ];
+    $this->assertEquals($expected, $parsed);
+  }
+
+  /**
+   * Ensure period within year test file is parsed correctly.
+   */
+  public function test_parse_period_within_year() {
+    $file = 'modules/data_cleaner/tests/rule_files/period_within_year.txt';
+    $filecontent = file_get_contents($file);
+    $parsed = data_cleaner::parseTestFile($filecontent);
+    $expected = [
+      'metadata' => [
+        'testtype' => 'PeriodWithinYear',
+        'group' => 'Period within year rule group',
+        'shortname' => 'Period within year rule name',
+        'description' => 'Period within year rule description',
+        'errormsg' => 'Period within year rule error message',
+        'tvk' => 'NBNSYS0100027431',
+        'startdate' => '0501',
+        'enddate' => '0930',
+        'lastchanged' => '20210816',
+      ],
+    ];
+    $this->assertEquals($expected, $parsed);
+  }
+
+  /**
+   * Ensure period within year test file with stage is parsed correctly.
+   */
+  public function test_parse_period_within_year_with_stage() {
+    $file = 'modules/data_cleaner/tests/rule_files/period_within_year_with_stage.txt';
+    $filecontent = file_get_contents($file);
+    $parsed = data_cleaner::parseTestFile($filecontent);
+    $expected = [
+      'metadata' => [
+        'testtype' => 'PeriodWithinYear',
+        'group' => 'Period within year rule group',
+        'shortname' => 'Period within year rule name',
+        'description' => 'Period within year rule description',
+        'errormsg' => 'Period within year rule error message',
+        'tvk' => 'NHMSYS0000504013',
+        'datafieldname' => 'Stage',
+        'lastchanged' => '20210816',
+      ],
+      'data' => [
+        '0' => [
+          'stage' => 'Larva',
+          'startdate' => '0515',
+          'enddate' => '0731',
+        ],
+        '1' => [
+          'stage' => 'Pupa',
+          'startdate' => '0701',
+          'enddate' => '0515',
+        ],
+        '2' => [
+          'stage' => 'Adult',
+          'startdate' => '0501',
+          'enddate' => '0630',
+        ],
+      ],
+    ];
+    $this->assertEquals($expected, $parsed);
+  }
+
+  /**
+   * Ensure period within year test file with stage is parsed correctly.
+   */
+  public function test_parse_without_polygon() {
+    $file = 'modules/data_cleaner/tests/rule_files/without_polygon.txt';
+    $filecontent = file_get_contents($file);
+    $parsed = data_cleaner::parseTestFile($filecontent);
+    $expected = [
+      'metadata' => [
+        'testtype' => 'WithoutPolygon',
+        'group' => 'Without polygon rule group',
+        'shortname' => 'Without polygon rule name',
+        'description' => 'Without polygon rule description',
+        'errormsg' => 'Without polygon rule error message',
+        'datafieldname' => 'Species',
+        'datarecordid' => 'NBNSYS0000007908',
+        'lastchanged' => '20210816',
+      ],
+      '10km_gb' => [
+        '0' => [
+          'nh80' => '-',
+          'nh91' => '-',
+          'nh95' => '-',
+        ],
+      ],
+    ];
+    $this->assertEquals($expected, $parsed);
+  }
+
+}

--- a/modules/data_cleaner/tests/rule_files/ancillary_species.txt
+++ b/modules/data_cleaner/tests/rule_files/ancillary_species.txt
@@ -1,0 +1,17 @@
+[Metadata]
+TestType=AncillarySpecies
+Group=Ancillary species rule group
+ShortName=Ancillary species rule name
+Description=Ancillary species rule description
+ErrorMsg=Ancillary species error message
+ReverseRule=True
+LastChanged=20210816
+[EndMetadata]
+
+[INI]
+1=Ancillary species message 1.
+2=Ancillary species message 2, with comma.
+
+[Data]
+NBNSYS0000007848,1
+NBNSYS0100004993,2

--- a/modules/data_cleaner/tests/rule_files/id_difficulty.txt
+++ b/modules/data_cleaner/tests/rule_files/id_difficulty.txt
@@ -1,0 +1,13 @@
+[Metadata]
+TestType=IdentificationDifficulty
+Organisation=Identification difficulty organisation
+LastChanged=20210816
+[EndMetadata]
+
+[INI]
+1=Identification difficulty message 1.
+2=Identification difficulty message 2, with comma.
+
+[Data]
+NBNSYS0000007825=1
+NBNSYS0000007826=2

--- a/modules/data_cleaner/tests/rule_files/period.txt
+++ b/modules/data_cleaner/tests/rule_files/period.txt
@@ -1,0 +1,11 @@
+[Metadata]
+TestType=Period
+Group=Period rule group
+ShortName=Period rule name
+Description=Period rule description
+ErrorMsg=Period rule error message
+Tvk=NBNSYS0100005964
+StartDate=
+EndDate=19581231
+LastChanged=20210816
+[EndMetadata]

--- a/modules/data_cleaner/tests/rule_files/period_within_year.txt
+++ b/modules/data_cleaner/tests/rule_files/period_within_year.txt
@@ -1,0 +1,11 @@
+[Metadata]
+TestType=PeriodWithinYear
+Group=Period within year rule group
+ShortName=Period within year rule name
+Description=Period within year rule description
+ErrorMsg=Period within year rule error message
+Tvk=NBNSYS0100027431
+StartDate=0501
+EndDate=0930
+LastChanged=20210816
+[EndMetadata]

--- a/modules/data_cleaner/tests/rule_files/period_within_year_with_stage.txt
+++ b/modules/data_cleaner/tests/rule_files/period_within_year_with_stage.txt
@@ -1,0 +1,23 @@
+[Metadata]
+TestType=PeriodWithinYear
+Group=Period within year rule group
+ShortName=Period within year rule name
+Description=Period within year rule description
+ErrorMsg=Period within year rule error message
+Tvk=NHMSYS0000504013
+DataFieldName=Stage
+LastChanged=20210816
+[EndMetadata]
+
+[Data]
+Stage=Larva
+StartDate=0515
+EndDate=0731
+
+Stage=Pupa
+StartDate=0701
+EndDate=0515
+
+Stage=Adult
+StartDate=0501
+EndDate=0630

--- a/modules/data_cleaner/tests/rule_files/without_polygon.txt
+++ b/modules/data_cleaner/tests/rule_files/without_polygon.txt
@@ -1,0 +1,15 @@
+[Metadata]
+TestType=WithoutPolygon
+Group=Without polygon rule group
+ShortName=Without polygon rule name
+Description=Without polygon rule description
+ErrorMsg=Without polygon rule error message
+DataFieldName=Species
+DataRecordId=NBNSYS0000007908
+LastChanged=20210816
+[EndMetadata]
+
+[10km_GB]
+NH80
+NH91
+NH95

--- a/modules/data_cleaner_without_polygon/plugins/data_cleaner_without_polygon.php
+++ b/modules/data_cleaner_without_polygon/plugins/data_cleaner_without_polygon.php
@@ -39,8 +39,8 @@ select distinct vr.id as verification_rule_id,
   vrd.value_geom as geom,
   vr.error_message
 from verification_rules vr
-join verification_rule_metadata vrmkey on vrmkey.key='DataRecordId' and vrmkey.deleted=false
-join verification_rule_metadata isSpecies on isSpecies.value='Species' and isSpecies.deleted=false
+join verification_rule_metadata vrmkey on vrmkey.verification_rule_id=vr.id and vrmkey.key='DataRecordId' and vrmkey.deleted=false
+join verification_rule_metadata isSpecies on isSpecies.verification_rule_id=vr.id and isSpecies.value='Species' and isSpecies.deleted=false
 join verification_rule_data vrd on vrd.verification_rule_id=vr.id and vrd.header_name='geom' and vrd.deleted=false
 where vr.test_type='WithoutPolygon'
 and vr.deleted=false


### PR DESCRIPTION
Fixes #390 - AncillarySpecies verification rules not being applied.
Fixes #395 - Script aborted importing verification rules.