### PR TITLE
cache_verification tables not being updated

### DIFF
--- a/application/config/version.php
+++ b/application/config/version.php
@@ -29,7 +29,7 @@ defined('SYSPATH') or die('No direct script access.');
  *
  * @var string
  */
-$config['version'] = '6.2.7';
+$config['version'] = '6.2.8';
 
 /**
  * Version release date.

--- a/modules/data_cleaner/controllers/verification_rule.php
+++ b/modules/data_cleaner/controllers/verification_rule.php
@@ -515,6 +515,7 @@ class Verification_rule_Controller extends Gridview_Base_Controller {
       $this->model->save_verification_rule_data($currentRule, $rulesettings);
     }
     $this->model->postProcessRule($currentRule);
+    $this->model->updateCache();
   }
 
   public function uploadRuleCsv($file) {

--- a/modules/data_cleaner/models/verification_rule.php
+++ b/modules/data_cleaner/models/verification_rule.php
@@ -377,13 +377,16 @@ class Verification_rule_Model extends ORM {
   /**
    * Overrides the postSubmit function to perform additional db changes.
    *
+   * Only applies when handling submissions from warehouse UI, not file uploads.
+   * * Update metadata and data tables
    * * Add in additional metadata calculated from other rule data.
    * * Allows rules which use a cache table for performance to update the
    *   cache.
    */
   protected function postSubmit($isInsert) {
     require_once DOCROOT . 'client_helpers/helper_base.php';
-    if (isset($this->submission['metaFields'])) {
+    if (isset($this->submission['metaFields']['metadata'])) {
+      // Submission is from warehouse UI.
       $currentRule = data_cleaner::getRule($this->test_type);
       if (isset($this->submission['metaFields']['metadata']['value'])) {
         $metadata = helper_base::explode_lines_key_value_pairs($this->submission['metaFields']['metadata']['value']);
@@ -391,8 +394,19 @@ class Verification_rule_Model extends ORM {
         $data = data_cleaner::parseTestFile($this->submission['metaFields']['data']['value']);
         $this->save_verification_rule_data($currentRule, $data);
         $this->postProcessRule($currentRule);
+        $this->updateCache();
       }
     }
+    return TRUE;
+  }
+
+  /**
+   * Update cache tables.
+   *
+   * Call this method after making any updates to a verification rule including
+   * the data and metadata.
+   */
+  public function updateCache() {
     // If the rule type uses a cache table to improve performance, update it.
     $rule = trim(strtolower(preg_replace('/([A-Z])/', '_$1', $this->test_type)), '_');
     require_once MODPATH . "data_cleaner_$rule/plugins/data_cleaner_$rule.php";
@@ -404,7 +418,6 @@ class Verification_rule_Model extends ORM {
         $this->db->query($sql);
       }
     }
-    return TRUE;
   }
 
 }


### PR DESCRIPTION
Fixes #397 - cache_verification tables not being updated

There are two paths to modifying verification rules, one directly via the website UI, the other by importing from files.

The updating of caches is moved to a function and called from both paths.