### PR TITLE
Fix for REST API locations end point

### DIFF
--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -2951,6 +2951,16 @@ class Rest_Controller extends Controller {
   }
 
   /**
+   * End-point to GET a list of locations.
+   *
+   * Only returns locations for user of website.
+   * @todo Add parameters to return public locations and locations by type. 
+   */
+  public function locationsGet() {
+    rest_crud::readList('location', 'AND t2.website_id=' . RestObjects::$clientWebsiteId);
+  }
+
+  /**
    * API end-point to retrieve a location by ID.
    *
    * @param int $id

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -2963,11 +2963,20 @@ class Rest_Controller extends Controller {
   /**
    * API end-point to retrieve a location by ID.
    *
+   * Only return locations for user of website or public locations.
+   *
    * @param int $id
    *   ID of the location.
    */
   public function locationsGetId($id) {
-    rest_crud::read('location', $id);
+    $websiteFilter = 't2.website_id=' . RestObjects::$clientWebsiteId;
+    $userFilter = 't1.created_by_id=' . RestObjects::$clientUserId;
+    $webUserFilter = "($websiteFilter AND $userFilter)";
+    $publicFilter = 't1.public=true';
+    $extraFilter = "AND ($webUserFilter OR $publicFilter)";
+    // Call read() with userFilter = FALSE as public locations may be
+    // created by another user.
+    rest_crud::read('location', $id, $extraFilter, FALSE);
   }
 
   /**

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -2430,11 +2430,11 @@ class Rest_Controller extends Controller {
       // this scope has been claimed by the token. We allow scope as a standard
       // claim or custom claim and as an array or space separated string for
       // wider compatibility with auth servers.
-      if (isset($payloadValues['http://indicia.org.uk/scope']) && !isset($payloadValues['scopes'])) {
-        $payloadValues['scopes'] = $payloadValues['http://indicia.org.uk/scope'];
+      if (isset($payloadValues['http://indicia.org.uk/scope']) && !isset($payloadValues['scope'])) {
+        $payloadValues['scope'] = $payloadValues['http://indicia.org.uk/scope'];
       }
-      if (!empty($payloadValues['scopes'])) {
-        $allowedScopes = is_array($payloadValues['scopes']) ? $payloadValues['scopes'] : explode(' ', $payloadValues['scopes']);
+      if (!empty($payloadValues['scope'])) {
+        $allowedScopes = is_array($payloadValues['scope']) ? $payloadValues['scope'] : explode(' ', $payloadValues['scope']);
         if (!empty($_GET['scope'])) {
           if (!in_array($_GET['scope'], $allowedScopes)) {
             RestObjects::$apiResponse->fail('Forbidden', 403, 'Attempt to access disallowed scope');

--- a/modules/rest_api/controllers/services/rest.php
+++ b/modules/rest_api/controllers/services/rest.php
@@ -2430,11 +2430,11 @@ class Rest_Controller extends Controller {
       // this scope has been claimed by the token. We allow scope as a standard
       // claim or custom claim and as an array or space separated string for
       // wider compatibility with auth servers.
-      if (isset($payloadValues['http://indicia.org.uk/scope']) && !isset($payloadValues['scope'])) {
-        $payloadValues['scope'] = $payloadValues['http://indicia.org.uk/scope'];
+      if (isset($payloadValues['http://indicia.org.uk/scope']) && !isset($payloadValues['scopes'])) {
+        $payloadValues['scopes'] = $payloadValues['http://indicia.org.uk/scope'];
       }
-      if (!empty($payloadValues['scope'])) {
-        $allowedScopes = is_array($payloadValues['scope']) ? $payloadValues['scope'] : explode(' ', $payloadValues['scope']);
+      if (!empty($payloadValues['scopes'])) {
+        $allowedScopes = is_array($payloadValues['scopes']) ? $payloadValues['scopes'] : explode(' ', $payloadValues['scopes']);
         if (!empty($_GET['scope'])) {
           if (!in_array($_GET['scope'], $allowedScopes)) {
             RestObjects::$apiResponse->fail('Forbidden', 403, 'Attempt to access disallowed scope');

--- a/modules/rest_api/entities/location.json
+++ b/modules/rest_api/entities/location.json
@@ -20,6 +20,12 @@
     { "sql": "name", "type": "string" },
     { "sql": "name", "type": "string" }
   ],
+  "joins": [
+    {
+      "sql": "LEFT JOIN locations_websites t2 ON t2.location_id=t1.id",
+      "fields": []
+    }
+  ],
   "subModels": {
     "locations": { "fk": "parent_id" },
     "media": { "fk": "location_id" },

--- a/modules/rest_api/tests/Rest_ControllerTest.php
+++ b/modules/rest_api/tests/Rest_ControllerTest.php
@@ -1381,11 +1381,22 @@ KEY;
   }
 
   /**
-   * A basic test of /locations GET.
+   * A basic test of /locations/id GET.
    */
   public function testJwtLocationGet() {
     $this->getTest('locations', [
       'name' => 'Location GET test',
+      'centroid_sref' => 'ST1234',
+      'centroid_sref_system' => 'OSGB',
+    ]);
+  }
+
+  /**
+   * A basic test of /locations GET.
+   */
+  public function testJwtLocationGetList() {
+    $this->getListTest('locations', [
+      'name' => 'Test Location ' . microtime(TRUE),
       'centroid_sref' => 'ST1234',
       'centroid_sref_system' => 'OSGB',
     ]);


### PR DESCRIPTION
Fixes #407 

- Adds a missing method for /locations end point, limiting the list to locations for the user and website.
- Adds a filter to the /locations/id endpoint so that locations are restricted by the website for the user. Also allows public locations to be returned.
- Fixes an error in processing the allowed scopes supplied in the JWT payload.