### PR TITLE
Deprecated function of warning for anonymous users

### DIFF
--- a/modules/indicia_svc_data/controllers/services/data_utils.php
+++ b/modules/indicia_svc_data/controllers/services/data_utils.php
@@ -379,7 +379,7 @@ SQL;
         $q = new WorkQueue();
         foreach ($ids as $id) {
           $q->enqueue($db, [
-            'task' => 'task_cache_builder_taxonomy_occurrence',
+            'task' => 'task_cache_builder_update',
             'entity' => 'occurrence',
             'record_id' => $id,
             'cost_estimate' => 50,


### PR DESCRIPTION
Here is the warning message regularly appeared.
Deprecated function: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in iform_user_ui_options_preprocess_iform() (line 113 of /code/web/modules/custom/iform/modules/iform_user_ui_options/iform_user_ui_options.module) 