### PR TITLE
Update amend name operation to deal with attr 'NONE'

### DIFF
--- a/modules/uksi_operations/controllers/uksi_operation.php
+++ b/modules/uksi_operations/controllers/uksi_operation.php
@@ -287,7 +287,11 @@ SQL;
         $tx->taxon = $operation->taxon_name;
       }
       if (!empty($operation->attribute)) {
-        $tx->attribute = $operation->attribute;
+        if ($operation->attribute === 'NONE') {
+          $tx->attribute = NULL;
+        } else {
+          $tx->attribute = $operation->attribute;
+        }
       }
       if (!empty($operation->authority)) {
         $tx->authority = $operation->authority;


### PR DESCRIPTION
The UKSI uksi_history table indicates the removal of an attribute in an 'amend name' operation by setting the value of the attribute field to the text string 'NONE'. Until now the uksi_operations module has mistakenly set the attribute to the string 'NONE'. This change sets the attribute to NULL when the string 'NONE' is found.