### PR TITLE
Sample Details map logic changes

### DIFF
--- a/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_child_parent_sample_details.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_child_parent_sample_details.xml
@@ -4,7 +4,11 @@
     Collect the section geometry, and also the parent transect location geometry"
 >
   <query website_filter_field="o.website_id" created_by_field="o.created_by_id" training_filter_field="o.training">
-    select 'parent' as type, s_parent.id, st_astext(l.boundary_geom) as geom
+    select 'parent' as type, s_parent.id, 
+    CASE WHEN (#allow_sensitive_full_precision# = 0 AND #includes_sensitive# = 1)
+    THEN '' 
+    ELSE st_astext(l.boundary_geom)
+    END as geom
     from cache_samples_functional csf
     JOIN samples s on s.id = csf.id
     JOIN samples s_parent on 
@@ -13,7 +17,11 @@
     where csf.id=#sample_id#
     and csf.website_id in (#website_ids#)
     union
-    select 'child' as type, csf.id, st_astext(l.boundary_geom) as geom
+    select 'child' as type, csf.id, 
+    CASE WHEN (#allow_sensitive_full_precision# = 0 AND #includes_sensitive# = 1)
+    THEN '' 
+    ELSE st_astext(l.boundary_geom) 
+    END as geom
     from cache_samples_functional csf
     join locations l on l.id=csf.location_id and l.deleted=false
     where csf.id=#sample_id#

--- a/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_child_parent_sample_details.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_child_parent_sample_details.xml
@@ -19,7 +19,11 @@
     where csf.id=#sample_id#
     and csf.website_id in (#website_ids#)
     union
-    select 'occurrence'  as type, o.id, st_astext(o.public_geom) as geom
+    select 'occurrence'  as type, o.id,
+    CASE WHEN #allow_sensitive_full_precision# = 0 AND #includes_sensitive# = 1 
+    THEN '' 
+    ELSE st_astext(o.public_geom) 
+    END as geom
     from cache_occurrences_functional o
     #agreements_join#
     where #sharing_filter#
@@ -27,6 +31,10 @@
   </query>
   <params>
     <param name='sample_id' display='Sample ID' description='ID of the subsample to load' datatype='text' />
+    <param name="allow_sensitive_full_precision" datatype="int" default="0"
+      description="Allow full precision even if sample includes a sensitive occurrence" />
+    <param name="includes_sensitive" datatype="int" default="0"
+      description="Does sample include a sensitive occurrence" />
   </params>
   <columns>
     <column name="type" datatype="text" />

--- a/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_child_parent_sample_details.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_child_parent_sample_details.xml
@@ -20,7 +20,8 @@
     and csf.website_id in (#website_ids#)
     union
     select 'occurrence'  as type, o.id,
-    CASE WHEN #allow_sensitive_full_precision# = 0 AND #includes_sensitive# = 1 
+    CASE WHEN (#allow_sensitive_full_precision# = 0 AND #includes_sensitive# = 1)
+    OR (#allow_unreleased# = 0 AND o.release_status != 'R')
     THEN '' 
     ELSE st_astext(o.public_geom) 
     END as geom
@@ -31,9 +32,11 @@
   </query>
   <params>
     <param name='sample_id' display='Sample ID' description='ID of the subsample to load' datatype='text' />
-    <param name="allow_sensitive_full_precision" datatype="int" default="0"
+    <param name="allow_unreleased" datatype="boolean" default="0"
+      description="Allow viewing of unreleased records" />
+    <param name="allow_sensitive_full_precision" datatype="boolean" default="0"
       description="Allow full precision even if sample includes a sensitive occurrence" />
-    <param name="includes_sensitive" datatype="int" default="0"
+    <param name="includes_sensitive" datatype="boolean" default="0"
       description="Does sample include a sensitive occurrence" />
   </params>
   <columns>

--- a/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_parent_child_sample_details.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_parent_child_sample_details.xml
@@ -7,7 +7,7 @@
     from cache_samples_functional s
     /* inner join, as only need location boundary geoms, samples are embedded in occurrences below. */
     join locations l on l.id=s.location_id and l.deleted=false
-    where s.parent_sample_id=#sample_id#
+    where (s.id=#sample_id# OR s.parent_sample_id=#sample_id#)
     and s.website_id in (#website_ids#)
     union
     select 'occurrence', o.id,

--- a/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_parent_child_sample_details.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_parent_child_sample_details.xml
@@ -3,7 +3,11 @@
     description="Geometry data summarising a parent/child sample."
 >
   <query website_filter_field="sp.website_id" created_by_field="sp.created_by_id" training_filter_field="">
-    select case when s.parent_sample_id IS NOT NULL THEN 'child' ELSE 'parent' END as type, s.id, st_astext(l.boundary_geom) as geom
+    select case when s.parent_sample_id IS NOT NULL THEN 'child' ELSE 'parent' END as type, s.id,
+    CASE WHEN (#allow_sensitive_full_precision# = 0 AND #includes_sensitive# = 1)
+    THEN '' 
+    ELSE st_astext(l.boundary_geom) 
+    END as geom
     from cache_samples_functional s
     /* inner join, as only need location boundary geoms, samples are embedded in occurrences below. */
     join locations l on l.id=s.location_id and l.deleted=false

--- a/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_parent_child_sample_details.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_parent_child_sample_details.xml
@@ -10,13 +10,21 @@
     where s.parent_sample_id=#sample_id#
     and s.website_id in (#website_ids#)
     union
-    select 'occurrence', o.id, st_astext(o.public_geom) as geom
+    select 'occurrence', o.id,
+    CASE WHEN #allow_sensitive_full_precision# = 0 AND #includes_sensitive# = 1
+    THEN '' 
+    ELSE st_astext(o.public_geom) 
+    END as geom
     from cache_occurrences_functional o
     where (o.parent_sample_id=#sample_id# or o.sample_id=#sample_id#)
     and o.website_id in (#website_ids#)
   </query>
   <params>
     <param name='sample_id' display='Sample ID' description='ID of the sample to load' datatype='text' />
+    <param name="allow_sensitive_full_precision" datatype="int" default="0"
+      description="Allow full precision even if sample includes a sensitive occurrence" />
+    <param name="includes_sensitive" datatype="int" default="0"
+      description="Does sample include a sensitive occurrence" />
   </params>
   <columns>
     <column name="type" datatype="text" />

--- a/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_parent_child_sample_details.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/extra_geoms_for_parent_child_sample_details.xml
@@ -3,7 +3,7 @@
     description="Geometry data summarising a parent/child sample."
 >
   <query website_filter_field="sp.website_id" created_by_field="sp.created_by_id" training_filter_field="">
-    select 'child' as type, s.id, st_astext(l.boundary_geom) as geom
+    select case when s.parent_sample_id IS NOT NULL THEN 'child' ELSE 'parent' END as type, s.id, st_astext(l.boundary_geom) as geom
     from cache_samples_functional s
     /* inner join, as only need location boundary geoms, samples are embedded in occurrences below. */
     join locations l on l.id=s.location_id and l.deleted=false
@@ -11,7 +11,8 @@
     and s.website_id in (#website_ids#)
     union
     select 'occurrence', o.id,
-    CASE WHEN #allow_sensitive_full_precision# = 0 AND #includes_sensitive# = 1
+    CASE WHEN (#allow_sensitive_full_precision# = 0 AND #includes_sensitive# = 1)
+    OR (#allow_unreleased# = 0 AND o.release_status != 'R')
     THEN '' 
     ELSE st_astext(o.public_geom) 
     END as geom
@@ -21,9 +22,11 @@
   </query>
   <params>
     <param name='sample_id' display='Sample ID' description='ID of the sample to load' datatype='text' />
+    <param name="allow_unreleased" datatype="boolean" default="0"
+      description="Allow viewing of unreleased records" />
     <param name="allow_sensitive_full_precision" datatype="int" default="0"
       description="Allow full precision even if sample includes a sensitive occurrence" />
-    <param name="includes_sensitive" datatype="int" default="0"
+    <param name="includes_sensitive" datatype="boolean" default="0"
       description="Does sample include a sensitive occurrence" />
   </params>
   <columns>

--- a/reports/reports_for_prebuilt_forms/sample_details/sample_data.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/sample_data.xml
@@ -45,7 +45,8 @@
     #joins#
     where #sharing_filter#
     AND (#allow_confidential# = 1 OR s.privacy_precision &gt; 0 OR s.privacy_precision IS NULL)
-    AND (#allow_unreleased# = 1 OR release_status = 'R' OR occurrence_id IS NULL)
+    -- Always include sensitive, as these are used to blur map (grid records are returned in different report)
+    AND (#allow_unreleased# = 1 OR release_status = 'R' OR occurrence_id IS NULL OR sensitive = true)
     AND NOT EXISTS
     (
       SELECT s.id

--- a/reports/reports_for_prebuilt_forms/sample_details/sample_data.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/sample_data.xml
@@ -46,8 +46,7 @@
     where #sharing_filter#
     AND (#allow_confidential# = 1 OR s.privacy_precision &gt; 0 OR s.privacy_precision IS NULL)
     -- Always include sensitive, as these are used to blur map
-    -- so must be returned by report (grid records are returned in different report).
-    -- Confidential is included in NOT EXISTS checks below so does not have same potential problem.
+    -- Note: confidential is included in NOT EXISTS checks below, so does not have same potential problem.
     AND (#allow_unreleased# = 1 OR release_status = 'R' OR occurrence_id IS NULL OR sensitive = true)
     AND NOT EXISTS
     (

--- a/reports/reports_for_prebuilt_forms/sample_details/sample_data.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/sample_data.xml
@@ -45,7 +45,9 @@
     #joins#
     where #sharing_filter#
     AND (#allow_confidential# = 1 OR s.privacy_precision &gt; 0 OR s.privacy_precision IS NULL)
-    -- Always include sensitive, as these are used to blur map (grid records are returned in different report)
+    -- Always include sensitive, as these are used to blur map
+    -- so must be returned by report (grid records are returned in different report).
+    -- Confidential is included in NOT EXISTS checks below so does not have same potential problem.
     AND (#allow_unreleased# = 1 OR release_status = 'R' OR occurrence_id IS NULL OR sensitive = true)
     AND NOT EXISTS
     (

--- a/reports/reports_for_prebuilt_forms/sample_details/sample_data.xml
+++ b/reports/reports_for_prebuilt_forms/sample_details/sample_data.xml
@@ -105,7 +105,11 @@
       when #allow_sensitive_full_precision#='1' then st_astext(geom)
       else coalesce(
         /* Show most sensitive polygon */
-        (select st_astext(o.public_geom) from cache_occurrences_nonfunctional onf join cache_occurrences_functional o on o.id = onf.id and o.sample_id = #sample_id# order by onf.sensitivity_precision desc nulls last limit 1),
+        (select st_astext(o.public_geom) 
+         from cache_occurrences_nonfunctional onf
+         join cache_occurrences_functional o on o.id = onf.id 
+         and (o.sample_id = #sample_id# OR o.parent_sample_id = #sample_id#)
+         order by onf.sensitivity_precision desc nulls last limit 1),
         /* If no occurrences, can revert to sample, but using public_geom allows for privacy. */
         st_astext(public_geom)
       )


### PR DESCRIPTION
Hi,

Quite a lot of changes to the logic on the sample details form.

1. Fixes problem where if an unreleased occurrence is sensitive, no blurring would occur on the map (commit 1883b8c).

2. When there are sensitive occurrences, make sure no location geometries are shown on the map at all (commit 79ac99b)

3. Make sure unreleased occurrence points do not appear on map. 
This is most obviously noticeable if there is a parent sample loaded onto Sample Details, and that sample has child samples, and one of the subsamples has all of its occurrences unreleased (commit d4d7431)
(also includes a minor fix to the "type" column which I forgot to mention in the git commit message)

4. Similar, but instead of unreleased, it is sensitive occurrence points we want to avoid showing (Commit 086645e).

5. When loading a parent sample, its location geometry would fail to show on map even though the sub-sample geometries do show (commit 8013852)
(am surprised this one actually wasn't noticed, can you confirm not deliberate for a reason unknown to me?)

6. If a parent sample is loaded, but the child sample has a sensitive occurrence, the blurring would fail because the occurrence check did not search sub-samples to get the highest sensitivity precision (commit 9a4b65d)

I have noticed another issue. Setting sensitive, then unsetting sensitive does not show the location geometry again like I mentioned the other day (although I think it fixes itself if you wait long enough).
I have noticed this on my own machine, and is fixed by deleting from cache tables, then running scheduled tasks.
I have not done anything about this.