### PR TITLE
Fix problem where sometimes updating existing records doesn't work

### DIFF
--- a/application/libraries/MY_ORM.php
+++ b/application/libraries/MY_ORM.php
@@ -2911,11 +2911,11 @@ class ORM extends ORM_Core {
                 }
               }
             }
-            if (!$wheresUpdated) {
-              return FALSE;
-            }
           }
       }
+    }
+    if (!$wheresUpdated) {
+      return FALSE;
     }
     return $wheres;
   }


### PR DESCRIPTION
Fix problem where sometimes updating existing records doesn't work. For example I couldn't get my location import to work updating existing rows based on external key, however the sample imports I did updating existing rows were fine.

The loop was returning false before it even got as far as checking if the external key field needed to be in the where statement.