### PR TITLE
Fix errors when updating existing records in importer1

### DIFF
--- a/application/libraries/MY_ORM.php
+++ b/application/libraries/MY_ORM.php
@@ -2838,24 +2838,26 @@ class ORM extends ORM_Core {
         if (!isset($saveArray[$field])) {
           return FALSE;
         }
-        $wheresUpdated = TRUE;
         if ($fieldTokens[0] === 'date') {
           $vd = vague_date::string_to_vague_date($saveArray[$field]);
-          $wheres .= " AND ($table.date_start = " . $escapeLiteral($vd[0]) . ')';
+          $wheres .= " ($table.date_start = " . $escapeLiteral($vd[0]) . ')';
           $wheres .= " AND ($table.date_end = " . $escapeLiteral($vd[1]) . ')';
           $wheres .= " AND ($table.date_type = " . $escapeLiteral($vd[2]) . ')';
         }
         else {
-          $wheres .= " AND ($table.$fieldTokens[0] = " . $escapeLiteral($saveArray[$field]) . ')';
+          $wheres .= " ($table.$fieldTokens[0] = " . $escapeLiteral($saveArray[$field]) . ')';
         }
+        $wheres = self::addAndToTheEndOfWhereClause($wheres);
+        $wheresUpdated = TRUE;
       } else {
         // There is a possibility that we are looking for for a supermodel id
         // which is represented as an ID in the supermodel itself. At this
         // point the $correctedField ends in _id.
         $superModelIDField = substr($fieldTokens[0], 0, -3); // cut off _id
         if (isset($saveArray[$superModelIDField . ':id'])) {
+          $wheres .= " ($table.$fieldTokens[0] = " . $escapeLiteral($saveArray[$superModelIDField . ':id']) . ')';
+          $wheres = self::addAndToTheEndOfWhereClause($wheres);
           $wheresUpdated = TRUE;
-          $wheres .= " AND ($table.$fieldTokens[0] = " . $escapeLiteral($saveArray[$superModelIDField . ':id']) . ')';
         }
         else {
           foreach ($saveArray as $saveField => $saveValue) {
@@ -2917,12 +2919,15 @@ class ORM extends ORM_Core {
                   }
                   $fk = $this->fkLookup($fkLookup);
                   if ($fk) {
-                    $wheres .= " AND ($table.$correctedField = " . $escapeLiteral($fk) . ')';
+                    $wheres .= " ($table.$correctedField = " . $escapeLiteral($fk) . ')';
+                    $wheres = self::addAndToTheEndOfWhereClause($wheres);
                     $wheresUpdated = TRUE;
                   }
                 } else {
-                  $wheres .= " AND ($table.$correctedField = " . $escapeLiteral($saveValue) . ')';
+                  $wheres .= " ($table.$correctedField = " . $escapeLiteral($saveValue) . ')';
+                  $wheres = self::addAndToTheEndOfWhereClause($wheres);
                   $wheresUpdated = TRUE;
+
                 }
               }
             }
@@ -2935,6 +2940,27 @@ class ORM extends ORM_Core {
         return FALSE;
       }
     }
+    // Remove AND from the end of the WHERE
+    // when the clause has finished being built.
+    $wheres = rtrim($wheres, " AND");
+    return $wheres;
+  }
+
+  /**
+   * Add AND on the end of the WHERE clause.
+   *
+   * Add an "AND" on the back of the WHERE clause as it is
+   * gradually built.
+   * The final AND will be removed elsewhere.
+   *
+   * @param array $wheres
+   *   The WHERE clause built so far.
+   *
+   * @return string
+   *   Return the WHERE clause built so far, with AND place on end.
+   */
+  private function addAndToTheEndOfWhereClause($wheres) {
+    $wheres .= " AND";
     return $wheres;
   }
 


### PR DESCRIPTION
Fixes errors when updating existing records in importer1, because it would always assume "AND" needed to be placed at the start of every part of the WHERE clause (it is not need on the first bit, and would break the importer).

An example error from warehouse would look like this. This occurred when I used "Parent and Code" to update existing location records.

"There was an SQL error: ERROR:  syntax error at or near "AND"
LINE 6:   AND  AND (locations.location_type_id = '778') AND (locatio...
               ^ -   SELECT DISTINCT "locations".id
  FROM "locations"
  JOIN locations_websites w ON (w.website_id=118 AND w.location_id = locations.id)

  WHERE "locations".deleted=false
  AND  AND (locations.location_type_id = '778') AND (locations.parent_id = '399337') AND (locations.code = 'S3')"